### PR TITLE
Updating spring-data-elasticsearch to 5.0.0-RC1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,13 +19,11 @@
 
 	<properties>
 		<springdata.commons>3.0.0-RC1</springdata.commons>
-		<springdata.elasticsearch>5.0.0-SNAPSHOT</springdata.elasticsearch>
+		<springdata.elasticsearch>5.0.0-RC1</springdata.elasticsearch>
 
 		<!-- version of the RestHighLevelClient	-->
 		<opensearch-rhlc>2.3.0</opensearch-rhlc>
-
 		<log4j>2.19.0</log4j>
-		<netty>4.1.82.Final</netty>
 
 		<hoverfly>0.14.3</hoverfly>
 		<jsonassert>1.5.1</jsonassert>
@@ -75,18 +73,6 @@
 		<system>GitHub</system>
 		<url>https://github.com/opensearch-project/spring-data-opensearch/issues</url>
 	</issueManagement>
-
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>io.netty</groupId>
-				<artifactId>netty-bom</artifactId>
-				<version>${netty}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
 
 	<dependencies>
 
@@ -366,9 +352,6 @@
 						<include>**/*Tests.java</include>
 						<include>**/*Test.java</include>
 					</includes>
-					<systemPropertyVariables>
-						<es.set.netty.runtime.available.processors>false</es.set.netty.runtime.available.processors>
-					</systemPropertyVariables>
 				</configuration>
 				<executions>
 					<!-- the default-test execution runs only the unit tests -->


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Updating spring-data-elasticsearch to 5.0.0-RC1 (released today)

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
