### PR TITLE
Corrects case for OpenSearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,32 @@
-Spring Data for Opensearch
+Spring Data for OpenSearch
 === 
 
 The primary goal of the [Spring Data](https://projects.spring.io/spring-data) project is to make it easier to build Spring-powered applications that use new data access technologies such as non-relational databases, map-reduce frameworks, and cloud based data services.
 
-The Spring Data Opensearch project provides [Spring Data](https://projects.spring.io/spring-data) compatible integration with the [Opensearch](https://opensearch.org/) search engine.
-Key functional areas of Spring Data Opensearch are a POJO centric model for interacting with a Opensearch Documents and easily writing a Repository style data access layer. This project is built on top of [Spring Data Elasticsearch](https://spring.io/projects/spring-data-elasticsearch/).
+The Spring Data OpenSearch project provides [Spring Data](https://projects.spring.io/spring-data) compatible integration with the [OpenSearch](https://opensearch.org/) search engine.
+Key functional areas of Spring Data OpenSearch are a POJO centric model for interacting with a OpenSearch Documents and easily writing a Repository style data access layer. This project is built on top of [Spring Data Elasticsearch](https://spring.io/projects/spring-data-elasticsearch/).
 
 ## Features
 
-* Spring configuration support using Java based `@Configuration` classes or an XML namespace for a Opensearch clients instances.
-* `ElasticsearchOperations` class and implementations that increases productivity performing common Opensearch operations.
+* Spring configuration support using Java based `@Configuration` classes or an XML namespace for a OpenSearch clients instances.
+* `ElasticsearchOperations` class and implementations that increases productivity performing common OpenSearch operations.
 Includes integrated object mapping between documents and POJOs.
 * Feature Rich Object Mapping integrated with Spring’s Conversion Service
 * Annotation based mapping metadata
 * Automatic implementation of `Repository` interfaces including support for custom search methods.
 * CDI support for repositories
 
-## About Opensearch versions and clients
+## About OpenSearch versions and clients
 
 ### Compatibility Matrix
 
-| Spring Data Release Train | Spring Data Opensearch | Spring Data Elasticsearch | Opensearch     | Spring Framework | Spring Boot |
+| Spring Data Release Train | Spring Data OpenSearch | Spring Data Elasticsearch | OpenSearch     | Spring Framework | Spring Boot |
 |---------------------------|------------------------|---------------------------|----------------|------------------|-------------|
 | 2022.0 (Turing)           | 0.1.x                  | 5.0.x                     | 1.3.6 / 2.3.0  | 6.0.x            | 3.0.x       |
 
-### Opensearch 2.x / 1.x client libraries
+### OpenSearch 2.x / 1.x client libraries
 
-At the moment, Spring Data Opensearch provides the possibility to use the `RestHighLevelCLient` to connect to Opensearch clusters. 
+At the moment, Spring Data OpenSearch provides the possibility to use the `RestHighLevelCLient` to connect to OpenSearch clusters. 
 
 ```xml
 <dependency>
@@ -74,25 +74,25 @@ public class MyService {
 }
 ```
 
-### Using the Opensearch RestClient
+### Using the OpenSearch RestClient
 
-Spring Data Opensearch operates upon an Opensearch client that is connected to a single Opensearch node or a cluster. Although the Opensearch Client can be used directly to work with the cluster, applications using Spring Data Elasticsearch normally use the higher level abstractions of `ElasticsearchOperations` and repositories (please consult [official Spring Data Elasticsearch documentation](https://docs.spring.io/spring-data/elasticsearch/docs/current/reference/html/)). Use the builder to provide cluster addresses, set default `HttpHeaders` or enable SSL.
+Spring Data OpenSearch operates upon an OpenSearch client that is connected to a single OpenSearch node or a cluster. Although the OpenSearch Client can be used directly to work with the cluster, applications using Spring Data Elasticsearch normally use the higher level abstractions of `ElasticsearchOperations` and repositories (please consult [official Spring Data Elasticsearch documentation](https://docs.spring.io/spring-data/elasticsearch/docs/current/reference/html/)). Use the builder to provide cluster addresses, set default `HttpHeaders` or enable SSL.
 
 ```java
-import org.opensearch.data.client.orhlc.AbstractOpensearchConfiguration;
+import org.opensearch.data.client.orhlc.AbstractOpenSearchConfiguration;
 import org.opensearch.data.client.orhlc.ClientConfiguration;
 import org.opensearch.data.client.orhlc.RestClients;
 
 @Configuration
-public class RestClientConfig extends AbstractOpensearchConfiguration {
+public class RestClientConfig extends AbstractOpenSearchConfiguration {
 
     @Override
     @Bean
     public RestHighLevelClient opensearchClient() {
 
         final ClientConfiguration clientConfiguration = ClientConfiguration.builder()
-            .connectedTo("localhost:9200")
-            .build();
+                .connectedTo("localhost:9200")
+                .build();
 
         return RestClients.create(clientConfiguration).rest();
     }
@@ -162,18 +162,18 @@ In this code snippet, the client configuration was customized to:
 - Set the socket timeout (default is `5 sec`).
 - Optionally set headers.
 - Add basic authentication.
-- A `Supplier<Header>` function can be specified which is called every time before a request is sent to Opensearch - here, as an example, the current time is written in a header.
+- A `Supplier<Header>` function can be specified which is called every time before a request is sent to OpenSearch - here, as an example, the current time is written in a header.
 - A function configuring the low level REST client
 
 ### Spring Boot integration
 
-If you are using Spring Data Opensearch along with Spring Boot (3.x milestone releases), you may consider excluding the `ElasticsearchDataAutoConfiguration` configuration from automatic discovery (otherwise, the `Elasticsearch` related initialization kicks in).
+If you are using Spring Data OpenSearch along with Spring Boot (3.x milestone releases), you may consider excluding the `ElasticsearchDataAutoConfiguration` configuration from automatic discovery (otherwise, the `Elasticsearch` related initialization kicks in).
 
 ```java
 @SpringBootApplication(exclude = {ElasticsearchDataAutoConfiguration.class})
-public class OpensearchDemoApplication {
+public class OpenSearchDemoApplication {
   public static void main(String[] args) {
-    SpringApplication.run(OpensearchDemoApplication.class, args);
+    SpringApplication.run(OpenSearchDemoApplication.class, args);
   }
 }
 ```
@@ -207,13 +207,13 @@ If you'd rather like the latest snapshots of the upcoming major version, use our
 
 ## Reporting Issues
 
-Spring Data Opensearch uses GitHub as issue tracking system to record bugs and feature requests.
+Spring Data OpenSearch uses GitHub as issue tracking system to record bugs and feature requests.
 If you want to raise an issue, please follow the recommendations below:
 
 * Before you log a bug, please search the
 [issue tracker](https://github.com/opensearch-project/spring-data-opensearch/issues) to see if someone has already reported the problem.
 * If the issue doesn’t already exist, [create a new issue](https://github.com/opensearch-project/spring-data-opensearch/issues/new).
-* Please provide as much information as possible with the issue report, we like to know the version of Spring Data Opensearch that you are using and JVM version.
+* Please provide as much information as possible with the issue report, we like to know the version of Spring Data OpenSearch that you are using and JVM version.
 * If you need to paste code, or include a stack trace use Markdown +++```+++ escapes before and after your text.
 * If possible try to create a test-case or project that replicates the issue.
 Attach a link to your code or a compressed file containing your code.
@@ -231,7 +231,7 @@ mvn clean install
 This project has adopted the [Amazon Open Source Code of Conduct](CODE_OF_CONDUCT.md). For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq), or contact [opensource-codeofconduct@amazon.com](mailto:opensource-codeofconduct@amazon.com) with any additional questions or comments.
 
 ## License
-Spring Data Opensearch is licensed under the Apache license, version 2.0. Full license text is available in the [LICENSE](LICENSE.txt) file.
+Spring Data OpenSearch is licensed under the Apache license, version 2.0. Full license text is available in the [LICENSE](LICENSE.txt) file.
 
 Please note that the project explicitly does not require a CLA (Contributor License Agreement) from its contributors.
 

--- a/src/main/java/org/opensearch/data/client/orhlc/AbstractOpenSearchConfiguration.java
+++ b/src/main/java/org/opensearch/data/client/orhlc/AbstractOpenSearchConfiguration.java
@@ -20,7 +20,7 @@ import org.springframework.data.elasticsearch.core.convert.ElasticsearchConverte
  * @see ElasticsearchConfigurationSupport
  * @since 0.1
  */
-public abstract class AbstractOpensearchConfiguration extends ElasticsearchConfigurationSupport {
+public abstract class AbstractOpenSearchConfiguration extends ElasticsearchConfigurationSupport {
 
     /**
      * Return the {@link RestHighLevelClient} instance used to connect to the cluster. <br />
@@ -39,7 +39,7 @@ public abstract class AbstractOpensearchConfiguration extends ElasticsearchConfi
     public ElasticsearchOperations elasticsearchOperations(
             ElasticsearchConverter elasticsearchConverter, RestHighLevelClient elasticsearchClient) {
 
-        OpensearchRestTemplate template = new OpensearchRestTemplate(elasticsearchClient, elasticsearchConverter);
+        OpenSearchRestTemplate template = new OpenSearchRestTemplate(elasticsearchClient, elasticsearchConverter);
         template.setRefreshPolicy(refreshPolicy());
 
         return template;

--- a/src/main/java/org/opensearch/data/client/orhlc/ClientConfiguration.java
+++ b/src/main/java/org/opensearch/data/client/orhlc/ClientConfiguration.java
@@ -22,7 +22,7 @@ import org.springframework.data.elasticsearch.support.HttpHeaders;
 import org.springframework.lang.Nullable;
 
 /**
- * Configuration interface exposing common client configuration properties for Opensearch clients.
+ * Configuration interface exposing common client configuration properties for OpenSearch clients.
  * @since 0.1
  */
 public interface ClientConfiguration {

--- a/src/main/java/org/opensearch/data/client/orhlc/DefaultClusterOperations.java
+++ b/src/main/java/org/opensearch/data/client/orhlc/DefaultClusterOperations.java
@@ -17,14 +17,14 @@ import org.springframework.data.elasticsearch.core.cluster.ClusterHealth;
 import org.springframework.data.elasticsearch.core.cluster.ClusterOperations;
 
 /**
- * Default implementation of {@link ClusterOperations} using the {@link OpensearchRestTemplate}.
+ * Default implementation of {@link ClusterOperations} using the {@link OpenSearchRestTemplate}.
  * @since 0.1
  */
 class DefaultClusterOperations implements ClusterOperations {
 
-    private final OpensearchRestTemplate template;
+    private final OpenSearchRestTemplate template;
 
-    DefaultClusterOperations(OpensearchRestTemplate template) {
+    DefaultClusterOperations(OpenSearchRestTemplate template) {
         this.template = template;
     }
 

--- a/src/main/java/org/opensearch/data/client/orhlc/HighlightQueryBuilder.java
+++ b/src/main/java/org/opensearch/data/client/orhlc/HighlightQueryBuilder.java
@@ -26,7 +26,7 @@ import org.springframework.lang.Nullable;
 import org.springframework.util.StringUtils;
 
 /**
- * Converts the {@link Highlight} annotation from a method to an Opensearch {@link HighlightBuilder}.
+ * Converts the {@link Highlight} annotation from a method to an OpenSearch {@link HighlightBuilder}.
  * @since 0.1
  */
 public class HighlightQueryBuilder {
@@ -41,7 +41,7 @@ public class HighlightQueryBuilder {
     }
 
     /**
-     * creates an Opensearch HighlightBuilder from an annotation.
+     * creates an OpenSearch HighlightBuilder from an annotation.
      *
      * @param highlight, must not be {@literal null}
      * @param type the entity type, used to map field names. If null, field names are not mapped.

--- a/src/main/java/org/opensearch/data/client/orhlc/NativeSearchQuery.java
+++ b/src/main/java/org/opensearch/data/client/orhlc/NativeSearchQuery.java
@@ -27,7 +27,7 @@ import org.springframework.data.elasticsearch.core.query.IndexBoost;
 import org.springframework.lang.Nullable;
 
 /**
- * A query created from Opensearch QueryBuilder instances. Note: the filter constructor parameter is used to create a
+ * A query created from OpenSearch QueryBuilder instances. Note: the filter constructor parameter is used to create a
  * post_filter
  * {@see https://www.elastic.co/guide/en/elasticsearch/reference/7.10/filter-search-results.html#post-filter}, if a
  * filter is needed that filters before aggregations are build, it must be included in the query constructor parameter.
@@ -140,7 +140,7 @@ public class NativeSearchQuery extends BaseQuery {
     }
 
     @Nullable
-    public List<SortBuilder<?>> getOpensearchSorts() {
+    public List<SortBuilder<?>> getOpenSearchSorts() {
         return sorts;
     }
 

--- a/src/main/java/org/opensearch/data/client/orhlc/OpenSearchAggregations.java
+++ b/src/main/java/org/opensearch/data/client/orhlc/OpenSearchAggregations.java
@@ -15,14 +15,14 @@ import org.springframework.data.elasticsearch.core.AggregationsContainer;
 import org.springframework.lang.NonNull;
 
 /**
- * AggregationsContainer implementation for the Opensearch aggregations.
+ * AggregationsContainer implementation for the OpenSearch aggregations.
  * @since 0.1
  */
-public class OpensearchAggregations implements AggregationsContainer<Aggregations> {
+public class OpenSearchAggregations implements AggregationsContainer<Aggregations> {
 
     private final Aggregations aggregations;
 
-    public OpensearchAggregations(Aggregations aggregations) {
+    public OpenSearchAggregations(Aggregations aggregations) {
         this.aggregations = aggregations;
     }
 

--- a/src/main/java/org/opensearch/data/client/orhlc/OpenSearchClusterOperations.java
+++ b/src/main/java/org/opensearch/data/client/orhlc/OpenSearchClusterOperations.java
@@ -14,17 +14,17 @@ import org.springframework.data.elasticsearch.core.cluster.ClusterOperations;
 import org.springframework.util.Assert;
 
 /**
- * Opensearch cluster operations
+ * OpenSearch cluster operations
  * @since 0.1
  */
-public class OpensearchClusterOperations {
+public class OpenSearchClusterOperations {
     /**
-     * Creates a ClusterOperations for a {@link OpensearchRestTemplate}.
+     * Creates a ClusterOperations for a {@link OpenSearchRestTemplate}.
      *
      * @param template the template, must not be {@literal null}
      * @return ClusterOperations
      */
-    public static ClusterOperations forTemplate(OpensearchRestTemplate template) {
+    public static ClusterOperations forTemplate(OpenSearchRestTemplate template) {
 
         Assert.notNull(template, "template must not be null");
 

--- a/src/main/java/org/opensearch/data/client/orhlc/OpenSearchExceptionTranslator.java
+++ b/src/main/java/org/opensearch/data/client/orhlc/OpenSearchExceptionTranslator.java
@@ -27,12 +27,12 @@ import org.springframework.data.elasticsearch.NoSuchIndexException;
 import org.springframework.data.elasticsearch.UncategorizedElasticsearchException;
 
 /**
- * Simple {@link PersistenceExceptionTranslator} for Opensearch. Convert the given runtime exception to an
+ * Simple {@link PersistenceExceptionTranslator} for OpenSearch. Convert the given runtime exception to an
  * appropriate exception from the {@code org.springframework.dao} hierarchy. Return {@literal null} if no translation is
  * appropriate: any other exception may have resulted from user code, and should not be translated.
  * @since 0.1
  */
-public class OpensearchExceptionTranslator implements PersistenceExceptionTranslator {
+public class OpenSearchExceptionTranslator implements PersistenceExceptionTranslator {
     /**
      * translates an Exception if possible. Exceptions that are no {@link RuntimeException}s are wrapped in a
      * RuntimeException

--- a/src/main/java/org/opensearch/data/client/orhlc/OpenSearchRestTemplate.java
+++ b/src/main/java/org/opensearch/data/client/orhlc/OpenSearchRestTemplate.java
@@ -74,19 +74,19 @@ import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
- * OpensearchRestTemplate
+ * OpenSearchRestTemplate
  * @since 0.1
  */
-public class OpensearchRestTemplate extends AbstractElasticsearchTemplate {
+public class OpenSearchRestTemplate extends AbstractElasticsearchTemplate {
 
-    private static final Log LOGGER = LogFactory.getLog(OpensearchRestTemplate.class);
+    private static final Log LOGGER = LogFactory.getLog(OpenSearchRestTemplate.class);
 
     private final RestHighLevelClient client;
-    private final OpensearchExceptionTranslator exceptionTranslator = new OpensearchExceptionTranslator();
+    private final OpenSearchExceptionTranslator exceptionTranslator = new OpenSearchExceptionTranslator();
     protected RequestFactory requestFactory;
 
     // region _initialization
-    public OpensearchRestTemplate(RestHighLevelClient client) {
+    public OpenSearchRestTemplate(RestHighLevelClient client) {
 
         Assert.notNull(client, "Client must not be null!");
 
@@ -94,7 +94,7 @@ public class OpensearchRestTemplate extends AbstractElasticsearchTemplate {
         requestFactory = new RequestFactory(this.elasticsearchConverter);
     }
 
-    public OpensearchRestTemplate(RestHighLevelClient client, ElasticsearchConverter opensearchConverter) {
+    public OpenSearchRestTemplate(RestHighLevelClient client, ElasticsearchConverter opensearchConverter) {
 
         super(opensearchConverter);
 
@@ -106,7 +106,7 @@ public class OpensearchRestTemplate extends AbstractElasticsearchTemplate {
 
     @Override
     protected AbstractElasticsearchTemplate doCopy() {
-        OpensearchRestTemplate copy = new OpensearchRestTemplate(client, elasticsearchConverter);
+        OpenSearchRestTemplate copy = new OpenSearchRestTemplate(client, elasticsearchConverter);
         copy.requestFactory = this.requestFactory;
         return copy;
     }
@@ -138,7 +138,7 @@ public class OpensearchRestTemplate extends AbstractElasticsearchTemplate {
     // region ClusterOperations
     @Override
     public ClusterOperations cluster() {
-        return OpensearchClusterOperations.forTemplate(this);
+        return OpenSearchClusterOperations.forTemplate(this);
     }
     // endregion
 
@@ -229,7 +229,7 @@ public class OpensearchRestTemplate extends AbstractElasticsearchTemplate {
         UpdateRequest request = requestFactory.updateRequest(query, index);
 
         if (query.getRefreshPolicy() == null && getRefreshPolicy() != null) {
-            request.setRefreshPolicy(RequestFactory.toOpensearchRefreshPolicy(getRefreshPolicy()));
+            request.setRefreshPolicy(RequestFactory.toOpenSearchRefreshPolicy(getRefreshPolicy()));
         }
 
         if (query.getRouting() == null && routingResolver.getRouting() != null) {
@@ -308,7 +308,7 @@ public class OpensearchRestTemplate extends AbstractElasticsearchTemplate {
             return request;
         }
 
-        return request.setRefreshPolicy(RequestFactory.toOpensearchRefreshPolicy(refreshPolicy));
+        return request.setRefreshPolicy(RequestFactory.toOpenSearchRefreshPolicy(refreshPolicy));
     }
 
     /**
@@ -612,7 +612,7 @@ public class OpensearchRestTemplate extends AbstractElasticsearchTemplate {
 
     @Override
     public String getVendor() {
-        return "Opensearch";
+        return "OpenSearch";
     }
 
     @Override

--- a/src/main/java/org/opensearch/data/client/orhlc/RequestFactory.java
+++ b/src/main/java/org/opensearch/data/client/orhlc/RequestFactory.java
@@ -111,7 +111,7 @@ import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 /**
- * Factory class to create Opensearch request instances from Spring Data Opensearch query objects.
+ * Factory class to create OpenSearch request instances from Spring Data OpenSearch query objects.
  * @since 0.1
  */
 class RequestFactory {
@@ -213,7 +213,7 @@ class RequestFactory {
         }
 
         if (bulkOptions.getRefreshPolicy() != null) {
-            bulkRequest.setRefreshPolicy(toOpensearchRefreshPolicy(bulkOptions.getRefreshPolicy()));
+            bulkRequest.setRefreshPolicy(toOpenSearchRefreshPolicy(bulkOptions.getRefreshPolicy()));
         }
 
         if (bulkOptions.getWaitForActiveShards() != null) {
@@ -797,7 +797,7 @@ class RequestFactory {
         }
 
         if (query.getIndicesOptions() != null) {
-            request.indicesOptions(toOpensearchIndicesOptions(query.getIndicesOptions()));
+            request.indicesOptions(toOpenSearchIndicesOptions(query.getIndicesOptions()));
         }
 
         if (query.isLimiting()) {
@@ -907,7 +907,7 @@ class RequestFactory {
 
         if (query instanceof NativeSearchQuery) {
             NativeSearchQuery nativeSearchQuery = (NativeSearchQuery) query;
-            List<SortBuilder<?>> sorts = nativeSearchQuery.getOpensearchSorts();
+            List<SortBuilder<?>> sorts = nativeSearchQuery.getOpenSearchSorts();
             if (sorts != null) {
                 sorts.forEach(sourceBuilder::sort);
             }
@@ -1060,7 +1060,7 @@ class RequestFactory {
         }
 
         if (query.getRefreshPolicy() != null) {
-            updateRequest.setRefreshPolicy(RequestFactory.toOpensearchRefreshPolicy(query.getRefreshPolicy()));
+            updateRequest.setRefreshPolicy(RequestFactory.toOpenSearchRefreshPolicy(query.getRefreshPolicy()));
         }
 
         if (query.getRetryOnConflict() != null) {
@@ -1097,7 +1097,7 @@ class RequestFactory {
             updateByQueryRequest.setQuery(getQuery(queryQuery));
 
             if (queryQuery.getIndicesOptions() != null) {
-                updateByQueryRequest.setIndicesOptions(toOpensearchIndicesOptions(queryQuery.getIndicesOptions()));
+                updateByQueryRequest.setIndicesOptions(toOpenSearchIndicesOptions(queryQuery.getIndicesOptions()));
             }
 
             if (queryQuery.getScrollTime() != null) {
@@ -1193,7 +1193,7 @@ class RequestFactory {
         return opensearchFilter;
     }
 
-    public static WriteRequest.RefreshPolicy toOpensearchRefreshPolicy(RefreshPolicy refreshPolicy) {
+    public static WriteRequest.RefreshPolicy toOpenSearchRefreshPolicy(RefreshPolicy refreshPolicy) {
         switch (refreshPolicy) {
             case IMMEDIATE:
                 return WriteRequest.RefreshPolicy.IMMEDIATE;
@@ -1217,7 +1217,7 @@ class RequestFactory {
         return null;
     }
 
-    public org.opensearch.action.support.IndicesOptions toOpensearchIndicesOptions(IndicesOptions indicesOptions) {
+    public org.opensearch.action.support.IndicesOptions toOpenSearchIndicesOptions(IndicesOptions indicesOptions) {
 
         Assert.notNull(indicesOptions, "indicesOptions must not be null");
 

--- a/src/main/java/org/opensearch/data/client/orhlc/ResponseConverter.java
+++ b/src/main/java/org/opensearch/data/client/orhlc/ResponseConverter.java
@@ -46,7 +46,7 @@ import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
- * Factory class to convert Opensearch responses to different type of data classes.
+ * Factory class to convert OpenSearch responses to different type of data classes.
  * @since 0.1
  */
 public class ResponseConverter {
@@ -108,7 +108,7 @@ public class ResponseConverter {
     /**
      * extract the index settings information from a given index
      *
-     * @param getIndexResponse the Opensearch GetIndexResponse
+     * @param getIndexResponse the OpenSearch GetIndexResponse
      * @param indexName the index name
      * @return a document that represents {@link Settings}
      */
@@ -130,7 +130,7 @@ public class ResponseConverter {
     /**
      * extract the mappings information from a given index
      *
-     * @param getIndexResponse the Opensearch GetIndexResponse
+     * @param getIndexResponse the OpenSearch GetIndexResponse
      * @param indexName the index name
      * @return a document that represents {@link MappingMetadata}
      */
@@ -204,12 +204,12 @@ public class ResponseConverter {
         if (responseHasMappings) {
             Object mappingsObj = getIndexResponse.getMappings().get(indexName);
             MappingMetadata mappings = null;
-            if (mappingsObj instanceof ImmutableOpenMap) { // Opensearch 1.x returns mapping types map
+            if (mappingsObj instanceof ImmutableOpenMap) { // OpenSearch 1.x returns mapping types map
                 @SuppressWarnings("unchecked")
                 final ImmutableOpenMap<String, MappingMetadata> mappingsMap =
                         (ImmutableOpenMap<String, MappingMetadata>) mappingsObj;
                 mappings = mappingsMap.get("_doc");
-            } else if (mappingsObj instanceof MappingMetadata) { // Opensearch 2.x returns mappings
+            } else if (mappingsObj instanceof MappingMetadata) { // OpenSearch 2.x returns mappings
                 mappings = (MappingMetadata) mappingsObj;
             }
 
@@ -275,7 +275,7 @@ public class ResponseConverter {
     /**
      * extract the index settings information for a given index
      *
-     * @param response the Opensearch response
+     * @param response the OpenSearch response
      * @param indexName the index name
      * @return settings
      */

--- a/src/main/java/org/opensearch/data/client/orhlc/RestClients.java
+++ b/src/main/java/org/opensearch/data/client/orhlc/RestClients.java
@@ -42,7 +42,7 @@ import org.springframework.data.elasticsearch.support.HttpHeaders;
 import org.springframework.util.Assert;
 
 /**
- * Utility class for common access to Opensearch clients. {@link RestClients} consolidates set up routines for the
+ * Utility class for common access to OpenSearch clients. {@link RestClients} consolidates set up routines for the
  * various drivers into a single place.
  * @since 0.1
  */
@@ -58,9 +58,9 @@ public final class RestClients {
     /**
      * Start here to create a new client tailored to your needs.
      *
-     * @return new instance of {@link OpensearchRestClient}.
+     * @return new instance of {@link OpenSearchRestClient}.
      */
-    public static OpensearchRestClient create(ClientConfiguration clientConfiguration) {
+    public static OpenSearchRestClient create(ClientConfiguration clientConfiguration) {
 
         Assert.notNull(clientConfiguration, "ClientConfiguration must not be null!");
 
@@ -142,7 +142,7 @@ public final class RestClients {
      * @author Christoph Strobl
      */
     @FunctionalInterface
-    public interface OpensearchRestClient extends Closeable {
+    public interface OpenSearchRestClient extends Closeable {
 
         /**
          * Apply the configuration to create a {@link RestHighLevelClient}.
@@ -167,7 +167,7 @@ public final class RestClients {
     }
 
     /**
-     * Logging interceptors for Opensearch client logging.
+     * Logging interceptors for OpenSearch client logging.
      *
      * @see ClientLogger
      */

--- a/src/main/java/org/opensearch/data/client/orhlc/RestIndexTemplate.java
+++ b/src/main/java/org/opensearch/data/client/orhlc/RestIndexTemplate.java
@@ -58,16 +58,16 @@ class RestIndexTemplate extends AbstractIndexTemplate implements IndexOperations
 
     private static final Log LOGGER = LogFactory.getLog(RestIndexTemplate.class);
 
-    private final OpensearchRestTemplate restTemplate;
+    private final OpenSearchRestTemplate restTemplate;
     protected final RequestFactory requestFactory;
 
-    public RestIndexTemplate(OpensearchRestTemplate restTemplate, Class<?> boundClass) {
+    public RestIndexTemplate(OpenSearchRestTemplate restTemplate, Class<?> boundClass) {
         super(restTemplate.getElasticsearchConverter(), boundClass);
         this.restTemplate = restTemplate;
         requestFactory = new RequestFactory(elasticsearchConverter);
     }
 
-    public RestIndexTemplate(OpensearchRestTemplate restTemplate, IndexCoordinates boundIndex) {
+    public RestIndexTemplate(OpenSearchRestTemplate restTemplate, IndexCoordinates boundIndex) {
         super(restTemplate.getElasticsearchConverter(), boundIndex);
         this.restTemplate = restTemplate;
         requestFactory = new RequestFactory(elasticsearchConverter);

--- a/src/main/java/org/opensearch/data/client/orhlc/SearchDocumentResponseBuilder.java
+++ b/src/main/java/org/opensearch/data/client/orhlc/SearchDocumentResponseBuilder.java
@@ -67,7 +67,7 @@ public class SearchDocumentResponseBuilder {
      * @param searchHits the {@link SearchHits} to process
      * @param scrollId scrollId
      * @param aggregations aggregations
-     * @param suggestOS the suggestion response from Opensearch
+     * @param suggestOS the suggestion response from OpenSearch
      * @param entityCreator function to create an entity from a {@link SearchDocument}
      * @param <T> entity type
      * @return the {@link SearchDocumentResponse}
@@ -101,8 +101,8 @@ public class SearchDocumentResponseBuilder {
             }
         }
 
-        OpensearchAggregations aggregationsContainer =
-                aggregations != null ? new OpensearchAggregations(aggregations) : null;
+        OpenSearchAggregations aggregationsContainer =
+                aggregations != null ? new OpenSearchAggregations(aggregations) : null;
         Suggest suggest = suggestFrom(suggestOS, entityCreator);
 
         return new SearchDocumentResponse(

--- a/src/main/java/org/opensearch/data/client/orhlc/SearchHitsUtil.java
+++ b/src/main/java/org/opensearch/data/client/orhlc/SearchHitsUtil.java
@@ -13,7 +13,7 @@ package org.opensearch.data.client.orhlc;
 import org.opensearch.search.SearchHits;
 
 /**
- * Utility class to prevent leaking of Lucene API into Spring Data Opensearch.
+ * Utility class to prevent leaking of Lucene API into Spring Data OpenSearch.
  * @since 0.1
  */
 public final class SearchHitsUtil {

--- a/src/test/java/org/opensearch/data/client/EnabledIfOpenSearchVersion.java
+++ b/src/test/java/org/opensearch/data/client/EnabledIfOpenSearchVersion.java
@@ -17,14 +17,14 @@ import java.lang.annotation.Target;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
- * Meta-annotation to enable Opensearch-specific test cases only on or after specific version
+ * Meta-annotation to enable OpenSearch-specific test cases only on or after specific version
  */
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
-@ExtendWith(EnabledIfOpensearchVersionCondition.class)
-public @interface EnabledIfOpensearchVersion {
+@ExtendWith(EnabledIfOpenSearchVersionCondition.class)
+public @interface EnabledIfOpenSearchVersion {
     /**
-     * The minimal required version of the Opensearch this test could run on
+     * The minimal required version of the OpenSearch this test could run on
      */
     String onOrAfter();
 

--- a/src/test/java/org/opensearch/data/client/EnabledIfOpenSearchVersionCondition.java
+++ b/src/test/java/org/opensearch/data/client/EnabledIfOpenSearchVersionCondition.java
@@ -17,14 +17,14 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.opensearch.Version;
 import org.springframework.data.elasticsearch.junit.jupiter.ClusterConnection;
 
-public class EnabledIfOpensearchVersionCondition implements ExecutionCondition {
+public class EnabledIfOpenSearchVersionCondition implements ExecutionCondition {
     @Override
     public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
         final AnnotatedElement element = context.getElement().orElseThrow(IllegalStateException::new);
 
-        final EnabledIfOpensearchVersion annotation = element.getAnnotation(EnabledIfOpensearchVersion.class);
+        final EnabledIfOpenSearchVersion annotation = element.getAnnotation(EnabledIfOpenSearchVersion.class);
         if (annotation == null) {
-            return ConditionEvaluationResult.enabled("@EnabledIfOpensearchVersion is not present");
+            return ConditionEvaluationResult.enabled("@EnabledIfOpenSearchVersion is not present");
         }
 
         final Version onOrAfter = Version.fromString(annotation.onOrAfter());

--- a/src/test/java/org/opensearch/data/client/JUnit5SampleOpenSearchRestTemplateTests.java
+++ b/src/test/java/org/opensearch/data/client/JUnit5SampleOpenSearchRestTemplateTests.java
@@ -13,28 +13,28 @@ import static org.assertj.core.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
-import org.opensearch.data.client.orhlc.OpensearchRestTemplate;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
+import org.opensearch.data.client.orhlc.OpenSearchRestTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.junit.jupiter.SpringIntegrationTest;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
- * class demonstrating the setup of a JUnit 5 test in Spring Data Opensearch that uses the rest client. The
- * ContextConfiguration must include the {@link OpensearchRestTemplateConfiguration} class.
+ * class demonstrating the setup of a JUnit 5 test in Spring Data OpenSearch that uses the rest client. The
+ * ContextConfiguration must include the {@link OpenSearchRestTemplateConfiguration} class.
  */
 @SpringIntegrationTest
-@ContextConfiguration(classes = {OpensearchRestTemplateConfiguration.class})
+@ContextConfiguration(classes = {OpenSearchRestTemplateConfiguration.class})
 @DisplayName("a sample JUnit 5 test with rest client")
-public class JUnit5SampleOpensearchRestTemplateTests {
+public class JUnit5SampleOpenSearchRestTemplateTests {
 
     @Autowired
     private ElasticsearchOperations elasticsearchOperations;
 
     @Test
-    @DisplayName("should have a OpensearchRestTemplate")
+    @DisplayName("should have a OpenSearchRestTemplate")
     void shouldHaveARestTemplate() {
-        assertThat(elasticsearchOperations).isNotNull().isInstanceOf(OpensearchRestTemplate.class);
+        assertThat(elasticsearchOperations).isNotNull().isInstanceOf(OpenSearchRestTemplate.class);
     }
 }

--- a/src/test/java/org/opensearch/data/client/NestedObjectORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/NestedObjectORHLCIntegrationTests.java
@@ -13,7 +13,7 @@ import static org.opensearch.index.query.QueryBuilders.*;
 
 import org.apache.lucene.search.join.ScoreMode;
 import org.jetbrains.annotations.NotNull;
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.opensearch.data.client.orhlc.NativeSearchQueryBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -26,7 +26,7 @@ import org.springframework.test.context.ContextConfiguration;
 @ContextConfiguration(classes = {NestedObjectORHLCIntegrationTests.Config.class})
 public class NestedObjectORHLCIntegrationTests extends NestedObjectIntegrationTests {
     @Configuration
-    @Import({OpensearchRestTemplateConfiguration.class})
+    @Import({OpenSearchRestTemplateConfiguration.class})
     static class Config {
         @Bean
         IndexNameProvider indexNameProvider() {

--- a/src/test/java/org/opensearch/data/client/config/AuditingORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/config/AuditingORHLCIntegrationTests.java
@@ -10,7 +10,7 @@
 package org.opensearch.data.client.config;
 
 
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.elasticsearch.config.AuditingIntegrationTests;
 import org.springframework.test.context.ContextConfiguration;
@@ -18,6 +18,6 @@ import org.springframework.test.context.ContextConfiguration;
 @ContextConfiguration(classes = {AuditingORHLCIntegrationTests.Config.class})
 public class AuditingORHLCIntegrationTests extends AuditingIntegrationTests {
 
-    @Import({OpensearchRestTemplateConfiguration.class, AuditingIntegrationTests.Config.class})
+    @Import({OpenSearchRestTemplateConfiguration.class, AuditingIntegrationTests.Config.class})
     static class Config {}
 }

--- a/src/test/java/org/opensearch/data/client/config/OpenSearchConfigurationSupportIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/config/OpenSearchConfigurationSupportIntegrationTests.java
@@ -18,8 +18,8 @@ import java.util.Set;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.RestHighLevelClient;
-import org.opensearch.data.client.orhlc.AbstractOpensearchConfiguration;
-import org.opensearch.data.client.orhlc.OpensearchRestTemplate;
+import org.opensearch.data.client.orhlc.AbstractOpenSearchConfiguration;
+import org.opensearch.data.client.orhlc.OpenSearchRestTemplate;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.support.AbstractApplicationContext;
@@ -30,10 +30,10 @@ import org.springframework.data.elasticsearch.core.mapping.SimpleElasticsearchMa
 import org.springframework.data.elasticsearch.junit.jupiter.Tags;
 
 /**
- * Integration tests for {@link OpensearchConfigurationSupport}.
+ * Integration tests for {@link OpenSearchConfigurationSupport}.
  */
 @Tag(Tags.INTEGRATION_TEST)
-public class OpensearchConfigurationSupportIntegrationTests {
+public class OpenSearchConfigurationSupportIntegrationTests {
 
     @Test // DATAES-504
     public void usesConfigClassPackageAsBaseMappingPackage() throws ClassNotFoundException {
@@ -72,10 +72,10 @@ public class OpensearchConfigurationSupportIntegrationTests {
     }
 
     @Test // DATAES-504
-    public void restConfigContainsOpensearchTemplate() {
+    public void restConfigContainsOpenSearchTemplate() {
 
         AbstractApplicationContext context = new AnnotationConfigApplicationContext(RestConfig.class);
-        assertThat(context.getBean(OpensearchRestTemplate.class)).isNotNull();
+        assertThat(context.getBean(OpenSearchRestTemplate.class)).isNotNull();
     }
 
     @Test // DATAES-563
@@ -101,7 +101,7 @@ public class OpensearchConfigurationSupportIntegrationTests {
     }
 
     @Configuration
-    static class RestConfig extends AbstractOpensearchConfiguration {
+    static class RestConfig extends AbstractOpenSearchConfiguration {
 
         @Override
         public RestHighLevelClient opensearchClient() {

--- a/src/test/java/org/opensearch/data/client/config/configuration/OpenSearchConfigurationORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/config/configuration/OpenSearchConfigurationORHLCIntegrationTests.java
@@ -15,7 +15,7 @@ import static org.mockito.Mockito.*;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.opensearch.client.RestHighLevelClient;
-import org.opensearch.data.client.orhlc.AbstractOpensearchConfiguration;
+import org.opensearch.data.client.orhlc.AbstractOpenSearchConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.annotation.Id;
@@ -27,11 +27,11 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /**
- * Tests for {@link AbstractOpensearchConfiguration}.
+ * Tests for {@link AbstractOpenSearchConfiguration}.
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration
-public class OpensearchConfigurationORHLCIntegrationTests {
+public class OpenSearchConfigurationORHLCIntegrationTests {
 
     /*
      * using a repository with an entity that is set to createIndex = false as we have no elastic running for this test
@@ -44,7 +44,7 @@ public class OpensearchConfigurationORHLCIntegrationTests {
     @EnableElasticsearchRepositories(
             basePackages = {"org.opensearch.data.client.config.configuration"},
             considerNestedRepositories = true)
-    static class Config extends AbstractOpensearchConfiguration {
+    static class Config extends AbstractOpenSearchConfiguration {
 
         @Override
         public RestHighLevelClient opensearchClient() {

--- a/src/test/java/org/opensearch/data/client/config/nested/EnableNestedRepositoriesORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/config/nested/EnableNestedRepositoriesORHLCIntegrationTests.java
@@ -10,7 +10,7 @@
 package org.opensearch.data.client.config.nested;
 
 
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -23,7 +23,7 @@ import org.springframework.test.context.ContextConfiguration;
 public class EnableNestedRepositoriesORHLCIntegrationTests extends EnableNestedRepositoriesIntegrationTests {
 
     @Configuration
-    @Import({OpensearchRestTemplateConfiguration.class})
+    @Import({OpenSearchRestTemplateConfiguration.class})
     @EnableElasticsearchRepositories(
             basePackages = {
                 "org.opensearch.data.client.config.nested",

--- a/src/test/java/org/opensearch/data/client/config/notnested/EnableRepositoriesORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/config/notnested/EnableRepositoriesORHLCIntegrationTests.java
@@ -10,7 +10,7 @@
 package org.opensearch.data.client.config.notnested;
 
 
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -21,7 +21,7 @@ import org.springframework.data.elasticsearch.utils.IndexNameProvider;
 public class EnableRepositoriesORHLCIntegrationTests extends EnableRepositoriesIntegrationTests {
 
     @Configuration
-    @Import({OpensearchRestTemplateConfiguration.class})
+    @Import({OpenSearchRestTemplateConfiguration.class})
     @EnableElasticsearchRepositories(basePackages = {"org.springframework.data.elasticsearch.config.notnested"})
     static class Config {
         @Bean

--- a/src/test/java/org/opensearch/data/client/core/InnerHitsORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/core/InnerHitsORHLCIntegrationTests.java
@@ -12,7 +12,7 @@ package org.opensearch.data.client.core;
 import static org.opensearch.index.query.QueryBuilders.*;
 
 import org.apache.lucene.search.join.ScoreMode;
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.opensearch.data.client.orhlc.NativeSearchQueryBuilder;
 import org.opensearch.index.query.InnerHitBuilder;
 import org.opensearch.index.query.NestedQueryBuilder;
@@ -28,7 +28,7 @@ import org.springframework.test.context.ContextConfiguration;
 public class InnerHitsORHLCIntegrationTests extends InnerHitsIntegrationTests {
 
     @Configuration
-    @Import({OpensearchRestTemplateConfiguration.class})
+    @Import({OpenSearchRestTemplateConfiguration.class})
     static class Config {
         @Bean
         IndexNameProvider indexNameProvider() {

--- a/src/test/java/org/opensearch/data/client/core/LogEntityORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/core/LogEntityORHLCIntegrationTests.java
@@ -11,7 +11,7 @@ package org.opensearch.data.client.core;
 
 import static org.opensearch.index.query.QueryBuilders.*;
 
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.opensearch.data.client.orhlc.NativeSearchQueryBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -24,7 +24,7 @@ import org.springframework.test.context.ContextConfiguration;
 @ContextConfiguration(classes = {LogEntityORHLCIntegrationTests.Config.class})
 public class LogEntityORHLCIntegrationTests extends LogEntityIntegrationTests {
     @Configuration
-    @Import({OpensearchRestTemplateConfiguration.class})
+    @Import({OpenSearchRestTemplateConfiguration.class})
     static class Config {
         @Bean
         IndexNameProvider indexNameProvider() {

--- a/src/test/java/org/opensearch/data/client/core/OpenSearchRestTemplateCallbackTests.java
+++ b/src/test/java/org/opensearch/data/client/core/OpenSearchRestTemplateCallbackTests.java
@@ -35,11 +35,11 @@ import org.opensearch.action.search.SearchScrollRequest;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.client.RestHighLevelClient;
 import org.opensearch.common.bytes.BytesArray;
-import org.opensearch.data.client.orhlc.OpensearchRestTemplate;
+import org.opensearch.data.client.orhlc.OpenSearchRestTemplate;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
-class OpensearchRestTemplateCallbackTests extends OpensearchTemplateCallbackTests {
+class OpenSearchRestTemplateCallbackTests extends OpenSearchTemplateCallbackTests {
 
     @Mock
     private RestHighLevelClient client;
@@ -68,7 +68,7 @@ class OpensearchRestTemplateCallbackTests extends OpensearchTemplateCallbackTest
     @SuppressWarnings("deprecation") // we know what we test
     @BeforeEach
     public void setUp() throws Exception {
-        initTemplate(new OpensearchRestTemplate(client));
+        initTemplate(new OpenSearchRestTemplate(client));
 
         doReturn(indexResponse).when(client).index(any(IndexRequest.class), any(RequestOptions.class));
         doReturn("response-id").when(indexResponse).getId();

--- a/src/test/java/org/opensearch/data/client/core/OpenSearchTemplateCallbackTests.java
+++ b/src/test/java/org/opensearch/data/client/core/OpenSearchTemplateCallbackTests.java
@@ -43,7 +43,7 @@ import org.springframework.data.mapping.callback.EntityCallbacks;
 import org.springframework.lang.Nullable;
 import org.springframework.util.CollectionUtils;
 
-abstract class OpensearchTemplateCallbackTests {
+abstract class OpenSearchTemplateCallbackTests {
 
     protected AbstractElasticsearchTemplate template;
 

--- a/src/test/java/org/opensearch/data/client/core/ReindexORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/core/ReindexORHLCIntegrationTests.java
@@ -10,7 +10,7 @@
 package org.opensearch.data.client.core;
 
 
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.opensearch.data.client.orhlc.NativeSearchQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.springframework.context.annotation.Bean;
@@ -25,7 +25,7 @@ import org.springframework.test.context.ContextConfiguration;
 public class ReindexORHLCIntegrationTests extends ReindexIntegrationTests {
 
     @Configuration
-    @Import({OpensearchRestTemplateConfiguration.class})
+    @Import({OpenSearchRestTemplateConfiguration.class})
     static class Config {
         @Bean
         IndexNameProvider indexNameProvider() {

--- a/src/test/java/org/opensearch/data/client/core/SearchAsYouTypeORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/core/SearchAsYouTypeORHLCIntegrationTests.java
@@ -10,7 +10,7 @@
 package org.opensearch.data.client.core;
 
 
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.opensearch.data.client.orhlc.NativeSearchQuery;
 import org.opensearch.index.query.MultiMatchQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
@@ -26,7 +26,7 @@ import org.springframework.test.context.ContextConfiguration;
 public class SearchAsYouTypeORHLCIntegrationTests extends SearchAsYouTypeIntegrationTests {
 
     @Configuration
-    @Import({OpensearchRestTemplateConfiguration.class})
+    @Import({OpenSearchRestTemplateConfiguration.class})
     static class Config {
         @Bean
         IndexNameProvider indexNameProvider() {

--- a/src/test/java/org/opensearch/data/client/core/SourceFilterORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/core/SourceFilterORHLCIntegrationTests.java
@@ -10,7 +10,7 @@
 package org.opensearch.data.client.core;
 
 
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -22,7 +22,7 @@ import org.springframework.test.context.ContextConfiguration;
 public class SourceFilterORHLCIntegrationTests extends SourceFilterIntegrationTests {
 
     @Configuration
-    @Import({OpensearchRestTemplateConfiguration.class})
+    @Import({OpenSearchRestTemplateConfiguration.class})
     static class Config {
         @Bean
         IndexNameProvider indexNameProvider() {

--- a/src/test/java/org/opensearch/data/client/core/aggregation/AggregationORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/core/aggregation/AggregationORHLCIntegrationTests.java
@@ -15,9 +15,9 @@ import static org.opensearch.search.aggregations.AggregationBuilders.*;
 import static org.opensearch.search.aggregations.PipelineAggregatorBuilders.*;
 
 import org.opensearch.action.search.SearchType;
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.opensearch.data.client.orhlc.NativeSearchQueryBuilder;
-import org.opensearch.data.client.orhlc.OpensearchAggregations;
+import org.opensearch.data.client.orhlc.OpenSearchAggregations;
 import org.opensearch.search.aggregations.Aggregation;
 import org.opensearch.search.aggregations.Aggregations;
 import org.opensearch.search.aggregations.pipeline.ParsedStatsBucket;
@@ -36,7 +36,7 @@ import org.springframework.test.context.ContextConfiguration;
 public class AggregationORHLCIntegrationTests extends AggregationIntegrationTests {
 
     @Configuration
-    @Import({OpensearchRestTemplateConfiguration.class})
+    @Import({OpenSearchRestTemplateConfiguration.class})
     @EnableElasticsearchRepositories(considerNestedRepositories = true)
     static class Config {
         @Bean
@@ -55,7 +55,7 @@ public class AggregationORHLCIntegrationTests extends AggregationIntegrationTest
     }
 
     protected void assertThatAggsHasResult(AggregationsContainer<?> aggregationsContainer, String aggsName) {
-        Aggregations aggregations = ((OpensearchAggregations) aggregationsContainer).aggregations();
+        Aggregations aggregations = ((OpenSearchAggregations) aggregationsContainer).aggregations();
         assertThat(aggregations.asMap().get(aggsName)).isNotNull();
     }
 
@@ -72,7 +72,7 @@ public class AggregationORHLCIntegrationTests extends AggregationIntegrationTest
 
     protected void assertThatPipelineAggsAreCorrect(
             AggregationsContainer<?> aggregationsContainer, String aggsName, String pipelineAggsName) {
-        Aggregations aggregations = ((OpensearchAggregations) aggregationsContainer).aggregations();
+        Aggregations aggregations = ((OpenSearchAggregations) aggregationsContainer).aggregations();
 
         assertThat(aggregations.asMap().get(aggsName)).isNotNull();
         Aggregation keyword_bucket_stats = aggregations.asMap().get(pipelineAggsName);

--- a/src/test/java/org/opensearch/data/client/core/cluster/ClusterOperationsORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/core/cluster/ClusterOperationsORHLCIntegrationTests.java
@@ -10,9 +10,9 @@
 package org.opensearch.data.client.core.cluster;
 
 
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.springframework.data.elasticsearch.core.cluster.ClusterOperationsIntegrationTests;
 import org.springframework.test.context.ContextConfiguration;
 
-@ContextConfiguration(classes = {OpensearchRestTemplateConfiguration.class})
+@ContextConfiguration(classes = {OpenSearchRestTemplateConfiguration.class})
 public class ClusterOperationsORHLCIntegrationTests extends ClusterOperationsIntegrationTests {}

--- a/src/test/java/org/opensearch/data/client/core/event/CallbackORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/core/event/CallbackORHLCIntegrationTests.java
@@ -10,7 +10,7 @@
 package org.opensearch.data.client.core.event;
 
 
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -22,7 +22,7 @@ import org.springframework.test.context.ContextConfiguration;
 class CallbackORHLCIntegrationTests extends CallbackIntegrationTests {
 
     @Configuration
-    @Import({OpensearchRestTemplateConfiguration.class, CallbackIntegrationTests.Config.class})
+    @Import({OpenSearchRestTemplateConfiguration.class, CallbackIntegrationTests.Config.class})
     static class Config {
         @Bean
         IndexNameProvider indexNameProvider() {

--- a/src/test/java/org/opensearch/data/client/core/geo/GeoJsonORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/core/geo/GeoJsonORHLCIntegrationTests.java
@@ -11,7 +11,7 @@ package org.opensearch.data.client.core.geo;
 
 
 import org.junit.jupiter.api.DisplayName;
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -23,7 +23,7 @@ import org.springframework.test.context.ContextConfiguration;
 @DisplayName("GeoJson integration test with RestHighLevelClient")
 public class GeoJsonORHLCIntegrationTests extends GeoJsonIntegrationTests {
     @Configuration
-    @Import({OpensearchRestTemplateConfiguration.class})
+    @Import({OpenSearchRestTemplateConfiguration.class})
     static class Config {
         @Bean
         IndexNameProvider indexNameProvider() {

--- a/src/test/java/org/opensearch/data/client/core/geo/GeoORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/core/geo/GeoORHLCIntegrationTests.java
@@ -10,7 +10,7 @@
 package org.opensearch.data.client.core.geo;
 
 
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.opensearch.data.client.orhlc.NativeSearchQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.springframework.context.annotation.Bean;
@@ -26,7 +26,7 @@ import org.springframework.test.context.ContextConfiguration;
 public class GeoORHLCIntegrationTests extends GeoIntegrationTests {
 
     @Configuration
-    @Import({OpensearchRestTemplateConfiguration.class})
+    @Import({OpenSearchRestTemplateConfiguration.class})
     @EnableElasticsearchRepositories(considerNestedRepositories = true)
     static class Config {
         @Bean

--- a/src/test/java/org/opensearch/data/client/core/index/IndexTemplateORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/core/index/IndexTemplateORHLCIntegrationTests.java
@@ -10,9 +10,9 @@
 package org.opensearch.data.client.core.index;
 
 
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.springframework.data.elasticsearch.core.index.IndexTemplateIntegrationTests;
 import org.springframework.test.context.ContextConfiguration;
 
-@ContextConfiguration(classes = {OpensearchRestTemplateConfiguration.class})
+@ContextConfiguration(classes = {OpenSearchRestTemplateConfiguration.class})
 public class IndexTemplateORHLCIntegrationTests extends IndexTemplateIntegrationTests {}

--- a/src/test/java/org/opensearch/data/client/core/index/MappingBuilderORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/core/index/MappingBuilderORHLCIntegrationTests.java
@@ -13,7 +13,7 @@ package org.opensearch.data.client.core.index;
 import java.util.List;
 import java.util.Map;
 import org.junit.Ignore;
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -31,7 +31,7 @@ import org.springframework.test.context.ContextConfiguration;
 public class MappingBuilderORHLCIntegrationTests extends MappingBuilderIntegrationTests {
 
     @Configuration
-    @Import({OpensearchRestTemplateConfiguration.class})
+    @Import({OpenSearchRestTemplateConfiguration.class})
     static class Config {
         @Bean
         IndexNameProvider indexNameProvider() {
@@ -48,13 +48,13 @@ public class MappingBuilderORHLCIntegrationTests extends MappingBuilderIntegrati
     @Ignore
     @Override
     public void shouldWriteRuntimeFields() {
-        // Not supported by Opensearch
+        // Not supported by OpenSearch
     }
 
     @Ignore
     @Override
     public void shouldWriteWildcardFieldMapping() {
-        // Not supported by Opensearch
+        // Not supported by OpenSearch
     }
 
     @Override

--- a/src/test/java/org/opensearch/data/client/core/indices/IndexOperationsORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/core/indices/IndexOperationsORHLCIntegrationTests.java
@@ -10,7 +10,7 @@
 package org.opensearch.data.client.core.indices;
 
 
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -22,7 +22,7 @@ import org.springframework.test.context.ContextConfiguration;
 public class IndexOperationsORHLCIntegrationTests extends IndexOperationsIntegrationTests {
 
     @Configuration
-    @Import({OpensearchRestTemplateConfiguration.class})
+    @Import({OpenSearchRestTemplateConfiguration.class})
     static class Config {
         @Bean
         IndexNameProvider indexNameProvider() {

--- a/src/test/java/org/opensearch/data/client/core/mapping/EntityCustomConversionORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/core/mapping/EntityCustomConversionORHLCIntegrationTests.java
@@ -11,7 +11,7 @@ package org.opensearch.data.client.core.mapping;
 
 
 import java.util.Arrays;
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -29,7 +29,7 @@ public class EntityCustomConversionORHLCIntegrationTests extends EntityCustomCon
     @EnableElasticsearchRepositories(
             basePackages = {"org.springframework.data.elasticsearch.core.mapping"},
             considerNestedRepositories = true)
-    static class Config extends OpensearchRestTemplateConfiguration {
+    static class Config extends OpenSearchRestTemplateConfiguration {
         @Bean
         IndexNameProvider indexNameProvider() {
             return new IndexNameProvider("entity-customconversions-operations-os");

--- a/src/test/java/org/opensearch/data/client/core/mapping/FieldNamingStrategyORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/core/mapping/FieldNamingStrategyORHLCIntegrationTests.java
@@ -11,7 +11,7 @@ package org.opensearch.data.client.core.mapping;
 
 import static org.opensearch.index.query.QueryBuilders.*;
 
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.opensearch.data.client.orhlc.NativeSearchQueryBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -26,7 +26,7 @@ import org.springframework.test.context.ContextConfiguration;
 public class FieldNamingStrategyORHLCIntegrationTests extends FieldNamingStrategyIntegrationTests {
 
     @Configuration
-    static class Config extends OpensearchRestTemplateConfiguration {
+    static class Config extends OpenSearchRestTemplateConfiguration {
 
         @Bean
         IndexNameProvider indexNameProvider() {

--- a/src/test/java/org/opensearch/data/client/core/paginating/SearchAfterORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/core/paginating/SearchAfterORHLCIntegrationTests.java
@@ -10,7 +10,7 @@
 package org.opensearch.data.client.core.paginating;
 
 
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -23,7 +23,7 @@ import org.springframework.test.context.ContextConfiguration;
 public class SearchAfterORHLCIntegrationTests extends SearchAfterIntegrationTests {
 
     @Configuration
-    @Import({OpensearchRestTemplateConfiguration.class})
+    @Import({OpenSearchRestTemplateConfiguration.class})
     @EnableElasticsearchRepositories(considerNestedRepositories = true)
     static class Config {
         @Bean

--- a/src/test/java/org/opensearch/data/client/core/query/CriteriaQueryORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/core/query/CriteriaQueryORHLCIntegrationTests.java
@@ -10,7 +10,7 @@
 package org.opensearch.data.client.core.query;
 
 
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -22,7 +22,7 @@ import org.springframework.test.context.ContextConfiguration;
 public class CriteriaQueryORHLCIntegrationTests extends CriteriaQueryIntegrationTests {
 
     @Configuration
-    @Import({OpensearchRestTemplateConfiguration.class})
+    @Import({OpenSearchRestTemplateConfiguration.class})
     static class Config {
         @Bean
         IndexNameProvider indexNameProvider() {

--- a/src/test/java/org/opensearch/data/client/core/routing/RoutingORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/core/routing/RoutingORHLCIntegrationTests.java
@@ -10,7 +10,7 @@
 package org.opensearch.data.client.core.routing;
 
 
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -22,7 +22,7 @@ import org.springframework.test.context.ContextConfiguration;
 public class RoutingORHLCIntegrationTests extends RoutingIntegrationTests {
 
     @Configuration
-    @Import({OpensearchRestTemplateConfiguration.class})
+    @Import({OpenSearchRestTemplateConfiguration.class})
     static class Config {
         @Bean
         IndexNameProvider indexNameProvider() {

--- a/src/test/java/org/opensearch/data/client/core/suggest/CompletionORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/core/suggest/CompletionORHLCIntegrationTests.java
@@ -11,7 +11,7 @@ package org.opensearch.data.client.core.suggest;
 
 
 import org.opensearch.common.unit.Fuzziness;
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.opensearch.data.client.orhlc.NativeSearchQueryBuilder;
 import org.opensearch.search.suggest.SuggestBuilder;
 import org.opensearch.search.suggest.SuggestBuilders;
@@ -28,7 +28,7 @@ import org.springframework.test.context.ContextConfiguration;
 public class CompletionORHLCIntegrationTests extends CompletionIntegrationTests {
 
     @Configuration
-    @Import({OpensearchRestTemplateConfiguration.class})
+    @Import({OpenSearchRestTemplateConfiguration.class})
     @EnableElasticsearchRepositories(considerNestedRepositories = true)
     static class Config {
         @Bean

--- a/src/test/java/org/opensearch/data/client/immutable/ImmutableRepositoryORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/immutable/ImmutableRepositoryORHLCIntegrationTests.java
@@ -10,7 +10,7 @@
 package org.opensearch.data.client.immutable;
 
 
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -23,7 +23,7 @@ import org.springframework.test.context.ContextConfiguration;
 public class ImmutableRepositoryORHLCIntegrationTests extends ImmutableRepositoryIntegrationTests {
 
     @Configuration
-    @Import({OpensearchRestTemplateConfiguration.class})
+    @Import({OpenSearchRestTemplateConfiguration.class})
     @EnableElasticsearchRepositories(
             basePackages = {"org.springframework.data.elasticsearch.immutable"},
             considerNestedRepositories = true)

--- a/src/test/java/org/opensearch/data/client/junit/jupiter/OpenSearchRestTemplateConfiguration.java
+++ b/src/test/java/org/opensearch/data/client/junit/jupiter/OpenSearchRestTemplateConfiguration.java
@@ -13,9 +13,9 @@ import static org.springframework.util.StringUtils.*;
 
 import java.time.Duration;
 import org.opensearch.client.RestHighLevelClient;
-import org.opensearch.data.client.orhlc.AbstractOpensearchConfiguration;
+import org.opensearch.data.client.orhlc.AbstractOpenSearchConfiguration;
 import org.opensearch.data.client.orhlc.ClientConfiguration;
-import org.opensearch.data.client.orhlc.OpensearchRestTemplate;
+import org.opensearch.data.client.orhlc.OpenSearchRestTemplate;
 import org.opensearch.data.client.orhlc.RestClients;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -27,10 +27,10 @@ import org.springframework.data.elasticsearch.core.convert.ElasticsearchConverte
 import org.springframework.data.elasticsearch.junit.jupiter.ClusterConnectionInfo;
 
 /**
- * Configuration for Spring Data Opensearch using {@link OpensearchRestTemplate}.
+ * Configuration for Spring Data OpenSearch using {@link OpenSearchRestTemplate}.
  */
 @Configuration
-public class OpensearchRestTemplateConfiguration extends AbstractOpensearchConfiguration {
+public class OpenSearchRestTemplateConfiguration extends AbstractOpenSearchConfiguration {
 
     @Autowired
     private ClusterConnectionInfo clusterConnectionInfo;
@@ -74,7 +74,7 @@ public class OpensearchRestTemplateConfiguration extends AbstractOpensearchConfi
     public ElasticsearchOperations elasticsearchOperations(
             ElasticsearchConverter elasticsearchConverter, RestHighLevelClient elasticsearchClient) {
 
-        OpensearchRestTemplate template = new OpensearchRestTemplate(elasticsearchClient, elasticsearchConverter) {
+        OpenSearchRestTemplate template = new OpenSearchRestTemplate(elasticsearchClient, elasticsearchConverter) {
             @Override
             public <T> T execute(ClientCallback<T> callback) {
                 try {

--- a/src/test/java/org/opensearch/data/client/orhlc/OpenSearchExceptionTranslatorIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/orhlc/OpenSearchExceptionTranslatorIntegrationTests.java
@@ -22,13 +22,13 @@ import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.data.elasticsearch.junit.jupiter.Tags;
 
 @Tag(Tags.INTEGRATION_TEST)
-class OpensearchExceptionTranslatorIntegrationTests {
-    private final OpensearchExceptionTranslator translator = new OpensearchExceptionTranslator();
+class OpenSearchExceptionTranslatorIntegrationTests {
+    private final OpenSearchExceptionTranslator translator = new OpenSearchExceptionTranslator();
 
     @Test // DATAES-799
-    void shouldConvertOpensearchStatusExceptionWithSeqNoConflictToOptimisticLockingFailureException() {
+    void shouldConvertOpenSearchStatusExceptionWithSeqNoConflictToOptimisticLockingFailureException() {
         OpenSearchStatusException ex = new OpenSearchStatusException(
-                "Opensearch exception [type=version_conflict_engine_exception, reason=[WPUUsXEB6uuA6j8_A7AB]: version conflict, required seqNo [34], primary term [16]. current document has seqNo [35] and primary term [16]]",
+                "OpenSearch exception [type=version_conflict_engine_exception, reason=[WPUUsXEB6uuA6j8_A7AB]: version conflict, required seqNo [34], primary term [16]. current document has seqNo [35] and primary term [16]]",
                 RestStatus.CONFLICT);
 
         DataAccessException translated = translator.translateExceptionIfPossible(ex);
@@ -43,7 +43,7 @@ class OpensearchExceptionTranslatorIntegrationTests {
         VersionConflictEngineException ex = new VersionConflictEngineException(
                 new ShardId("index", "uuid", 1),
                 "exception-id",
-                "Opensearch exception [type=version_conflict_engine_exception, reason=[WPUUsXEB6uuA6j8_A7AB]: version conflict, required seqNo [34], primary term [16]. current document has seqNo [35] and primary term [16]]");
+                "OpenSearch exception [type=version_conflict_engine_exception, reason=[WPUUsXEB6uuA6j8_A7AB]: version conflict, required seqNo [34], primary term [16]. current document has seqNo [35] and primary term [16]]");
 
         DataAccessException translated = translator.translateExceptionIfPossible(ex);
 

--- a/src/test/java/org/opensearch/data/client/orhlc/OpenSearchORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/orhlc/OpenSearchORHLCIntegrationTests.java
@@ -26,8 +26,8 @@ import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.common.lucene.search.function.CombineFunction;
 import org.opensearch.common.lucene.search.function.FunctionScoreQuery;
 import org.opensearch.common.unit.TimeValue;
-import org.opensearch.data.client.EnabledIfOpensearchVersion;
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.EnabledIfOpenSearchVersion;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.opensearch.index.query.InnerHitBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.functionscore.FunctionScoreQueryBuilder;
@@ -54,12 +54,12 @@ import org.springframework.data.elasticsearch.utils.IndexNameProvider;
 import org.springframework.lang.Nullable;
 import org.springframework.test.context.ContextConfiguration;
 
-@ContextConfiguration(classes = {OpensearchORHLCIntegrationTests.Config.class})
-@DisplayName("Using Opensearch RestHighLevelClient")
-public class OpensearchORHLCIntegrationTests extends ElasticsearchIntegrationTests {
+@ContextConfiguration(classes = {OpenSearchORHLCIntegrationTests.Config.class})
+@DisplayName("Using OpenSearch RestHighLevelClient")
+public class OpenSearchORHLCIntegrationTests extends ElasticsearchIntegrationTests {
 
     @Configuration
-    @Import({OpensearchRestTemplateConfiguration.class})
+    @Import({OpenSearchRestTemplateConfiguration.class})
     static class Config {
         @Bean
         IndexNameProvider indexNameProvider() {
@@ -293,7 +293,7 @@ public class OpensearchORHLCIntegrationTests extends ElasticsearchIntegrationTes
     }
 
     @Test
-    @EnabledIfOpensearchVersion(
+    @EnabledIfOpenSearchVersion(
             onOrAfter = "2.0.0",
             reason = "https://github.com/opensearch-project/OpenSearch/issues/4749")
     @Override
@@ -302,6 +302,6 @@ public class OpensearchORHLCIntegrationTests extends ElasticsearchIntegrationTes
     }
 
     private RequestFactory getRequestFactory() {
-        return ((OpensearchRestTemplate) operations).getRequestFactory();
+        return ((OpenSearchRestTemplate) operations).getRequestFactory();
     }
 }

--- a/src/test/java/org/opensearch/data/client/orhlc/OpenSearchPartQueryORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/orhlc/OpenSearchPartQueryORHLCIntegrationTests.java
@@ -10,7 +10,7 @@
 package org.opensearch.data.client.orhlc;
 
 
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -23,11 +23,11 @@ import org.springframework.test.context.ContextConfiguration;
  * The base class for these tests lives in the org.opensearch.data.client.core.query package, but we need
  * access to the {@link RequestFactory} class here
  */
-@ContextConfiguration(classes = {OpensearchPartQueryORHLCIntegrationTests.Config.class})
-public class OpensearchPartQueryORHLCIntegrationTests extends ElasticsearchPartQueryIntegrationTests {
+@ContextConfiguration(classes = {OpenSearchPartQueryORHLCIntegrationTests.Config.class})
+public class OpenSearchPartQueryORHLCIntegrationTests extends ElasticsearchPartQueryIntegrationTests {
 
     @Configuration
-    @Import({OpensearchRestTemplateConfiguration.class})
+    @Import({OpenSearchRestTemplateConfiguration.class})
     static class Config {}
 
     protected String buildQueryString(CriteriaQuery criteriaQuery, Class<?> clazz) {

--- a/src/test/java/org/opensearch/data/client/orhlc/RequestFactoryIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/orhlc/RequestFactoryIntegrationTests.java
@@ -986,17 +986,17 @@ class RequestFactoryIntegrationTests {
     }
 
     @Test // #2075
-    @DisplayName("should not fail on empty Option set during toOpensearchIndicesOptions")
+    @DisplayName("should not fail on empty Option set during toOpenSearchIndicesOptions")
     void shouldNotFailOnEmptyOptionsOnToElasticsearchIndicesOptions() {
-        assertThat(requestFactory.toOpensearchIndicesOptions(new IndicesOptions(
+        assertThat(requestFactory.toOpenSearchIndicesOptions(new IndicesOptions(
                         EnumSet.noneOf(IndicesOptions.Option.class), EnumSet.of(IndicesOptions.WildcardStates.OPEN))))
                 .isNotNull();
     }
 
     @Test // #2075
-    @DisplayName("should not fail on empty WildcardState set during toOpensearchIndicesOptions")
+    @DisplayName("should not fail on empty WildcardState set during toOpenSearchIndicesOptions")
     void shouldNotFailOnEmptyWildcardStatesOnToElasticsearchIndicesOptions() {
-        assertThat(requestFactory.toOpensearchIndicesOptions(
+        assertThat(requestFactory.toOpenSearchIndicesOptions(
                         IndicesOptions.STRICT_SINGLE_INDEX_NO_EXPAND_FORBID_CLOSED))
                 .isNotNull();
     }

--- a/src/test/java/org/opensearch/data/client/orhlc/RestClientsIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/orhlc/RestClientsIntegrationTests.java
@@ -202,7 +202,7 @@ public class RestClientsIntegrationTests {
         });
     }
 
-    private StubMapping stubForOpensearchVersionCheck() {
+    private StubMapping stubForOpenSearchVersionCheck() {
         return stubFor(get(urlEqualTo("/")) //
                 .willReturn(okJson("{\n" + //
                                 "    \"cluster_name\": \"docker-cluster\",\n"
@@ -263,7 +263,7 @@ public class RestClientsIntegrationTests {
 
     /**
      * starts a Wiremock server and calls consumer with the server as argument. Stops the server after consumer execution.
-     * Before the consumer ids called the {@link #stubForHead()} and {@link #stubForOpensearchVersionCheck()} are
+     * Before the consumer ids called the {@link #stubForHead()} and {@link #stubForOpenSearchVersionCheck()} are
      * registered.
      *
      * @param consumer the consumer
@@ -279,7 +279,7 @@ public class RestClientsIntegrationTests {
             wireMockServer.start();
             WireMock.configureFor(wireMockServer.port());
             stubForHead();
-            stubForOpensearchVersionCheck();
+            stubForOpenSearchVersionCheck();
 
             consumer.accept(wireMockServer);
         } finally {

--- a/src/test/java/org/opensearch/data/client/repositories/cdi/ElasticsearchOperationsProducer.java
+++ b/src/test/java/org/opensearch/data/client/repositories/cdi/ElasticsearchOperationsProducer.java
@@ -15,9 +15,9 @@ import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import org.opensearch.data.client.orhlc.ClientConfiguration;
-import org.opensearch.data.client.orhlc.OpensearchRestTemplate;
+import org.opensearch.data.client.orhlc.OpenSearchRestTemplate;
 import org.opensearch.data.client.orhlc.RestClients;
-import org.opensearch.data.client.orhlc.RestClients.OpensearchRestClient;
+import org.opensearch.data.client.orhlc.RestClients.OpenSearchRestClient;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.junit.jupiter.ClusterConnection;
 import org.springframework.data.elasticsearch.junit.jupiter.ClusterConnectionInfo;
@@ -28,15 +28,15 @@ import org.springframework.data.elasticsearch.repositories.cdi.PersonDB;
 public class ElasticsearchOperationsProducer {
 
     @Produces
-    public ElasticsearchOperations createElasticsearchTemplate(OpensearchRestClient client) {
-        return new OpensearchRestTemplate(client.rest());
+    public ElasticsearchOperations createElasticsearchTemplate(OpenSearchRestClient client) {
+        return new OpenSearchRestTemplate(client.rest());
     }
 
     @Produces
     @OtherQualifier
     @PersonDB
-    public ElasticsearchOperations createQualifiedOpensearchTemplate(OpensearchRestClient client) {
-        return new OpensearchRestTemplate(client.rest());
+    public ElasticsearchOperations createQualifiedOpenSearchTemplate(OpenSearchRestClient client) {
+        return new OpenSearchRestTemplate(client.rest());
     }
 
     @PreDestroy
@@ -45,7 +45,7 @@ public class ElasticsearchOperationsProducer {
     }
 
     @Produces
-    public OpensearchRestClient opensearchClient() {
+    public OpenSearchRestClient opensearchClient() {
         // we rely on the tests being run with the SpringDataElasticsearchExtension class that sets up a containerized
         // ES.
         ClusterConnectionInfo connectionInfo = ClusterConnection.clusterConnectionInfo();

--- a/src/test/java/org/opensearch/data/client/repositories/complex/custommethod/autowiring/ComplexCustomMethodRepositoryORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/repositories/complex/custommethod/autowiring/ComplexCustomMethodRepositoryORHLCIntegrationTests.java
@@ -10,7 +10,7 @@
 package org.opensearch.data.client.repositories.complex.custommethod.autowiring;
 
 
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -23,7 +23,7 @@ import org.springframework.test.context.ContextConfiguration;
 public class ComplexCustomMethodRepositoryORHLCIntegrationTests extends ComplexCustomMethodRepositoryIntegrationTests {
 
     @Configuration
-    @Import({OpensearchRestTemplateConfiguration.class})
+    @Import({OpenSearchRestTemplateConfiguration.class})
     @EnableElasticsearchRepositories(
             basePackages = {"org.springframework.data.elasticsearch.repositories.complex.custommethod.autowiring"},
             considerNestedRepositories = true)

--- a/src/test/java/org/opensearch/data/client/repositories/complex/custommethod/manualwiring/ComplexCustomMethodRepositoryManualWiringORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/repositories/complex/custommethod/manualwiring/ComplexCustomMethodRepositoryManualWiringORHLCIntegrationTests.java
@@ -10,7 +10,7 @@
 package org.opensearch.data.client.repositories.complex.custommethod.manualwiring;
 
 
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -24,7 +24,7 @@ public class ComplexCustomMethodRepositoryManualWiringORHLCIntegrationTests
         extends ComplexCustomMethodRepositoryManualWiringIntegrationTests {
 
     @Configuration
-    @Import({OpensearchRestTemplateConfiguration.class})
+    @Import({OpenSearchRestTemplateConfiguration.class})
     @EnableElasticsearchRepositories(
             basePackages = {"org.springframework.data.elasticsearch.repositories.complex.custommethod.manualwiring"},
             considerNestedRepositories = true)

--- a/src/test/java/org/opensearch/data/client/repositories/custommethod/CustomMethodRepositoryORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/repositories/custommethod/CustomMethodRepositoryORHLCIntegrationTests.java
@@ -10,7 +10,7 @@
 package org.opensearch.data.client.repositories.custommethod;
 
 
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -23,7 +23,7 @@ import org.springframework.test.context.ContextConfiguration;
 public class CustomMethodRepositoryORHLCIntegrationTests extends CustomMethodRepositoryIntegrationTests {
 
     @Configuration
-    @Import({OpensearchRestTemplateConfiguration.class})
+    @Import({OpenSearchRestTemplateConfiguration.class})
     @EnableElasticsearchRepositories(
             basePackages = {"org.springframework.data.elasticsearch.repositories.custommethod"},
             considerNestedRepositories = true)

--- a/src/test/java/org/opensearch/data/client/repositories/doubleid/DoubleIDRepositoryORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/repositories/doubleid/DoubleIDRepositoryORHLCIntegrationTests.java
@@ -10,7 +10,7 @@
 package org.opensearch.data.client.repositories.doubleid;
 
 
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -23,7 +23,7 @@ import org.springframework.test.context.ContextConfiguration;
 public class DoubleIDRepositoryORHLCIntegrationTests extends DoubleIDRepositoryIntegrationTests {
 
     @Configuration
-    @Import({OpensearchRestTemplateConfiguration.class})
+    @Import({OpenSearchRestTemplateConfiguration.class})
     @EnableElasticsearchRepositories(
             basePackages = {"org.springframework.data.elasticsearch.repositories.doubleid"},
             considerNestedRepositories = true)

--- a/src/test/java/org/opensearch/data/client/repositories/dynamicindex/DynamicIndexEntityORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/repositories/dynamicindex/DynamicIndexEntityORHLCIntegrationTests.java
@@ -10,7 +10,7 @@
 package org.opensearch.data.client.repositories.dynamicindex;
 
 
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -21,7 +21,7 @@ import org.springframework.test.context.ContextConfiguration;
 @ContextConfiguration(classes = {DynamicIndexEntityORHLCIntegrationTests.Config.class})
 public class DynamicIndexEntityORHLCIntegrationTests extends DynamicIndexEntityIntegrationTests {
     @Configuration
-    @Import({OpensearchRestTemplateConfiguration.class})
+    @Import({OpenSearchRestTemplateConfiguration.class})
     @EnableElasticsearchRepositories(
             basePackages = {"org.springframework.data.elasticsearch.repositories.dynamicindex"},
             considerNestedRepositories = true)

--- a/src/test/java/org/opensearch/data/client/repositories/geo/GeoRepositoryORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/repositories/geo/GeoRepositoryORHLCIntegrationTests.java
@@ -10,7 +10,7 @@
 package org.opensearch.data.client.repositories.geo;
 
 
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -22,7 +22,7 @@ import org.springframework.test.context.ContextConfiguration;
 @ContextConfiguration(classes = {GeoRepositoryORHLCIntegrationTests.Config.class})
 public class GeoRepositoryORHLCIntegrationTests extends GeoRepositoryIntegrationTests {
     @Configuration
-    @Import({OpensearchRestTemplateConfiguration.class})
+    @Import({OpenSearchRestTemplateConfiguration.class})
     @EnableElasticsearchRepositories(
             basePackages = {"org.springframework.data.elasticsearch.repositories.geo"},
             considerNestedRepositories = true)

--- a/src/test/java/org/opensearch/data/client/repositories/integer/IntegerIDRepositoryORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/repositories/integer/IntegerIDRepositoryORHLCIntegrationTests.java
@@ -10,7 +10,7 @@
 package org.opensearch.data.client.repositories.integer;
 
 
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -23,7 +23,7 @@ import org.springframework.test.context.ContextConfiguration;
 public class IntegerIDRepositoryORHLCIntegrationTests extends IntegerIDRepositoryIntegrationTests {
 
     @Configuration
-    @Import({OpensearchRestTemplateConfiguration.class})
+    @Import({OpenSearchRestTemplateConfiguration.class})
     @EnableElasticsearchRepositories(
             basePackages = {"org.springframework.data.elasticsearch.repositories.integer"},
             considerNestedRepositories = true)

--- a/src/test/java/org/opensearch/data/client/repositories/nestedobject/InnerObjectORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/repositories/nestedobject/InnerObjectORHLCIntegrationTests.java
@@ -10,7 +10,7 @@
 package org.opensearch.data.client.repositories.nestedobject;
 
 
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -22,7 +22,7 @@ import org.springframework.test.context.ContextConfiguration;
 @ContextConfiguration(classes = {InnerObjectORHLCIntegrationTests.Config.class})
 public class InnerObjectORHLCIntegrationTests extends InnerObjectIntegrationTests {
     @Configuration
-    @Import({OpensearchRestTemplateConfiguration.class})
+    @Import({OpenSearchRestTemplateConfiguration.class})
     @EnableElasticsearchRepositories(
             basePackages = {"org.springframework.data.elasticsearch.repositories.nestedobject"},
             considerNestedRepositories = true)

--- a/src/test/java/org/opensearch/data/client/repositories/setting/dynamic/DynamicSettingAndMappingEntityRepositoryORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/repositories/setting/dynamic/DynamicSettingAndMappingEntityRepositoryORHLCIntegrationTests.java
@@ -10,7 +10,7 @@
 package org.opensearch.data.client.repositories.setting.dynamic;
 
 
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -24,7 +24,7 @@ public class DynamicSettingAndMappingEntityRepositoryORHLCIntegrationTests
         extends DynamicSettingAndMappingEntityRepositoryIntegrationTests {
 
     @Configuration
-    @Import({OpensearchRestTemplateConfiguration.class})
+    @Import({OpenSearchRestTemplateConfiguration.class})
     @EnableElasticsearchRepositories(
             basePackages = {"org.springframework.data.elasticsearch.repositories.setting.dynamic"},
             considerNestedRepositories = true)

--- a/src/test/java/org/opensearch/data/client/repositories/setting/fielddynamic/FieldDynamicMappingEntityRepositoryORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/repositories/setting/fielddynamic/FieldDynamicMappingEntityRepositoryORHLCIntegrationTests.java
@@ -10,7 +10,7 @@
 package org.opensearch.data.client.repositories.setting.fielddynamic;
 
 
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -24,7 +24,7 @@ public class FieldDynamicMappingEntityRepositoryORHLCIntegrationTests
         extends FieldDynamicMappingEntityRepositoryIntegrationTests {
 
     @Configuration
-    @Import({OpensearchRestTemplateConfiguration.class})
+    @Import({OpenSearchRestTemplateConfiguration.class})
     @EnableElasticsearchRepositories(
             basePackages = {"org.springframework.data.elasticsearch.repositories.setting.fielddynamic"},
             considerNestedRepositories = true)

--- a/src/test/java/org/opensearch/data/client/repositories/spel/SpELEntityORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/repositories/spel/SpELEntityORHLCIntegrationTests.java
@@ -10,7 +10,7 @@
 package org.opensearch.data.client.repositories.spel;
 
 
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -22,7 +22,7 @@ import org.springframework.test.context.ContextConfiguration;
 @ContextConfiguration(classes = {SpELEntityORHLCIntegrationTests.Config.class})
 public class SpELEntityORHLCIntegrationTests extends SpELEntityIntegrationTests {
     @Configuration
-    @Import(OpensearchRestTemplateConfiguration.class)
+    @Import(OpenSearchRestTemplateConfiguration.class)
     @EnableElasticsearchRepositories(
             basePackages = {"org.springframework.data.elasticsearch.repositories.spel"},
             considerNestedRepositories = true)

--- a/src/test/java/org/opensearch/data/client/repositories/synonym/SynonymRepositoryORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/repositories/synonym/SynonymRepositoryORHLCIntegrationTests.java
@@ -10,7 +10,7 @@
 package org.opensearch.data.client.repositories.synonym;
 
 
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -22,7 +22,7 @@ import org.springframework.test.context.ContextConfiguration;
 @ContextConfiguration(classes = {SynonymRepositoryORHLCIntegrationTests.Config.class})
 public class SynonymRepositoryORHLCIntegrationTests extends SynonymRepositoryIntegrationTests {
     @Configuration
-    @Import({OpensearchRestTemplateConfiguration.class})
+    @Import({OpenSearchRestTemplateConfiguration.class})
     @EnableElasticsearchRepositories(
             basePackages = {"org.springframework.data.elasticsearch.repositories.synonym"},
             considerNestedRepositories = true)

--- a/src/test/java/org/opensearch/data/client/repositories/uuidkeyed/UUIDElasticsearchRepositoryORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/repositories/uuidkeyed/UUIDElasticsearchRepositoryORHLCIntegrationTests.java
@@ -10,7 +10,7 @@
 package org.opensearch.data.client.repositories.uuidkeyed;
 
 
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -22,7 +22,7 @@ import org.springframework.test.context.ContextConfiguration;
 @ContextConfiguration(classes = {UUIDElasticsearchRepositoryORHLCIntegrationTests.Config.class})
 public class UUIDElasticsearchRepositoryORHLCIntegrationTests extends UUIDElasticsearchRepositoryIntegrationTests {
     @Configuration
-    @Import({OpensearchRestTemplateConfiguration.class})
+    @Import({OpenSearchRestTemplateConfiguration.class})
     @EnableElasticsearchRepositories(
             basePackages = {"org.springframework.data.elasticsearch.repositories.uuidkeyed"},
             considerNestedRepositories = true)

--- a/src/test/java/org/opensearch/data/client/repository/query/keywords/QueryKeywordsORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/repository/query/keywords/QueryKeywordsORHLCIntegrationTests.java
@@ -10,7 +10,7 @@
 package org.opensearch.data.client.repository.query.keywords;
 
 
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -20,13 +20,14 @@ import org.springframework.data.elasticsearch.utils.IndexNameProvider;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
- * {@link QueryKeywordsIntegrationTests} using a Repository backed by an OpensearchRestTemplate.
+ * {@link QueryKeywordsIntegrationTests} using a Repository backed by an
+ * {@link org.opensearch.data.client.orhlc.OpenSearchRestTemplate}.
  */
 @ContextConfiguration(classes = {QueryKeywordsORHLCIntegrationTests.Config.class})
 public class QueryKeywordsORHLCIntegrationTests extends QueryKeywordsIntegrationTests {
 
     @Configuration
-    @Import({OpensearchRestTemplateConfiguration.class})
+    @Import({OpenSearchRestTemplateConfiguration.class})
     @EnableElasticsearchRepositories(
             basePackages = {"org.springframework.data.elasticsearch.repository.query.keywords"},
             considerNestedRepositories = true)

--- a/src/test/java/org/opensearch/data/client/repository/support/ElasticsearchRepositoryORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/repository/support/ElasticsearchRepositoryORHLCIntegrationTests.java
@@ -10,7 +10,7 @@
 package org.opensearch.data.client.repository.support;
 
 
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -23,7 +23,7 @@ import org.springframework.test.context.ContextConfiguration;
 public class ElasticsearchRepositoryORHLCIntegrationTests extends ElasticsearchRepositoryIntegrationTests {
 
     @Configuration
-    @Import({OpensearchRestTemplateConfiguration.class})
+    @Import({OpenSearchRestTemplateConfiguration.class})
     @EnableElasticsearchRepositories(
             basePackages = {"org.springframework.data.elasticsearch.repository.support"},
             considerNestedRepositories = true)

--- a/src/test/java/org/springframework/data/elasticsearch/core/index/MappingBuilderIntegrationTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/index/MappingBuilderIntegrationTests.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
-import org.opensearch.data.client.junit.jupiter.OpensearchRestTemplateConfiguration;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -71,7 +71,7 @@ import org.springframework.lang.Nullable;
 public abstract class MappingBuilderIntegrationTests extends MappingContextBaseTests {
 
 	@Configuration
-	@Import({ OpensearchRestTemplateConfiguration.class })
+	@Import({ OpenSearchRestTemplateConfiguration.class })
 	static class Config {
 		@Bean
 		IndexNameProvider indexNameProvider() {

--- a/src/test/resources/testcontainers-opensearch.properties
+++ b/src/test/resources/testcontainers-opensearch.properties
@@ -5,6 +5,6 @@ sde.testcontainers.image-name=opensearchproject/opensearch
 sde.testcontainers.image-version=${sde.testcontainers.image-version}
 #
 #
-# Opensearch as default has TLS and Basic auth enabled, we do not want this here, Testcontainers cannot ignore self signed certificates
+# OpenSearch as default has TLS and Basic auth enabled, we do not want this here, Testcontainers cannot ignore self signed certificates
 #
 plugins.security.disabled=true


### PR DESCRIPTION
### Description

Updates class names, method names, and documentation to use "OpenSearch" with a capital "S." This will help developers who are used to this casing (e.g. from the opensearch-java) client.

Package names remain the same.

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
