### PR TITLE
Added David Venable to MAINTAINERS.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,5 +4,6 @@
 |------------------------|---------------------------------------------------|-------------|
 | Andriy Redko           | [reta](https://github.com/reta)                   | Aiven       |
 | Daniel Doubrovkine     | [dblock](https://github.com/dblock)               | Amazon      |
+| David Venable          | [dlvenable](https://github.com/dlvenable)         | Amazon      |
 
 [This document](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md) explains what maintainers do in this repo, and how they should be doing it. If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).


### PR DESCRIPTION
Signed-off-by: Daniel (dB.) Doubrovkine <dblock@amazon.com>

### Description

Adding @dlvenable to MAITNAINERS unanimously voted in by the existing maintainers for his great early engagement with [a handful of PRs](https://github.com/opensearch-project/spring-data-opensearch/pulls/dlvenable), open issues, code reviews, etc.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
