### PR TITLE
Remove Spring snapshots Apache Maven repository coordinates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -502,8 +502,8 @@
 
 	<repositories>
 		<repository>
-			<id>spring-libs-snapshot</id>
-			<url>https://repo.spring.io/libs-snapshot</url>
+			<id>spring-libs-milestone</id>
+			<url>https://repo.spring.io/milestone/</url>
 		</repository>
 
 		<repository>


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Remove Spring snapshots Apache Maven repository coordinates

### Issues Resolved
Related to https://github.com/opensearch-project/spring-data-opensearch/pull/5

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
