### PR TITLE
Remove org.jetbrains.annotations usage in favor of org.springframework.lang.NonNull

### DIFF
--- a/src/test/java/org/opensearch/data/client/NestedObjectORHLCIntegrationTests.java
+++ b/src/test/java/org/opensearch/data/client/NestedObjectORHLCIntegrationTests.java
@@ -12,7 +12,6 @@ package org.opensearch.data.client;
 import static org.opensearch.index.query.QueryBuilders.*;
 
 import org.apache.lucene.search.join.ScoreMode;
-import org.jetbrains.annotations.NotNull;
 import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.opensearch.data.client.orhlc.NativeSearchQueryBuilder;
 import org.springframework.context.annotation.Bean;
@@ -21,6 +20,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.elasticsearch.NestedObjectIntegrationTests;
 import org.springframework.data.elasticsearch.core.query.Query;
 import org.springframework.data.elasticsearch.utils.IndexNameProvider;
+import org.springframework.lang.NonNull;
 import org.springframework.test.context.ContextConfiguration;
 
 @ContextConfiguration(classes = {NestedObjectORHLCIntegrationTests.Config.class})
@@ -34,7 +34,7 @@ public class NestedObjectORHLCIntegrationTests extends NestedObjectIntegrationTe
         }
     }
 
-    @NotNull
+    @NonNull
     protected Query getNestedQuery1() {
         return new NativeSearchQueryBuilder()
                 .withQuery( //
@@ -47,7 +47,7 @@ public class NestedObjectORHLCIntegrationTests extends NestedObjectIntegrationTe
                 .build();
     }
 
-    @NotNull
+    @NonNull
     protected Query getNestedQuery2() {
         return new NativeSearchQueryBuilder()
                 .withQuery( //
@@ -63,7 +63,7 @@ public class NestedObjectORHLCIntegrationTests extends NestedObjectIntegrationTe
                 .build();
     }
 
-    @NotNull
+    @NonNull
     protected Query getNestedQuery3() {
         return new NativeSearchQueryBuilder()
                 .withQuery( //
@@ -75,7 +75,7 @@ public class NestedObjectORHLCIntegrationTests extends NestedObjectIntegrationTe
                 .build();
     }
 
-    @NotNull
+    @NonNull
     protected Query getNestedQuery4() {
         return new NativeSearchQueryBuilder()
                 .withQuery( //

--- a/src/test/java/org/springframework/data/elasticsearch/NestedObjectIntegrationTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/NestedObjectIntegrationTests.java
@@ -26,7 +26,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -45,6 +44,7 @@ import org.springframework.data.elasticsearch.core.query.IndexQuery;
 import org.springframework.data.elasticsearch.core.query.Query;
 import org.springframework.data.elasticsearch.junit.jupiter.SpringIntegrationTest;
 import org.springframework.data.elasticsearch.utils.IndexNameProvider;
+import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
 
 /**
@@ -130,7 +130,7 @@ public abstract class NestedObjectIntegrationTests {
 		assertThat(persons).hasSize(1);
 	}
 
-	@NotNull
+	@NonNull
 	abstract protected Query getNestedQuery1();
 
 	@Test
@@ -185,7 +185,7 @@ public abstract class NestedObjectIntegrationTests {
 		assertThat(personIndexed.getSearchHit(0).getContent().getId()).isEqualTo("1");
 	}
 
-	@NotNull
+	@NonNull
 	abstract protected Query getNestedQuery2();
 
 	private List<IndexQuery> createPerson() {
@@ -320,7 +320,7 @@ public abstract class NestedObjectIntegrationTests {
 		assertThat(persons).hasSize(1);
 	}
 
-	@NotNull
+	@NonNull
 	abstract protected Query getNestedQuery3();
 
 	@Test // DATAES-73
@@ -368,7 +368,7 @@ public abstract class NestedObjectIntegrationTests {
 		assertThat(books.getSearchHit(0).getContent().getId()).isEqualTo(book2.getId());
 	}
 
-	@NotNull
+	@NonNull
 	abstract protected Query getNestedQuery4();
 
 	@Document(indexName = "#{@indexNameProvider.indexName()}-book")


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Remove org.jetbrains.annotations usage in favor of org.springframework.lang.NonNull

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
