### PR TITLE
Fixes the Gradle assemble task

### DIFF
--- a/src/main/java/org/opensearch/data/client/orhlc/ClientConfiguration.java
+++ b/src/main/java/org/opensearch/data/client/orhlc/ClientConfiguration.java
@@ -118,7 +118,6 @@ public interface ClientConfiguration {
      * Returns the {@link java.time.Duration connect timeout}.
      *
      * @see java.net.Socket#connect(SocketAddress, int)
-     * @see io.netty.channel.ChannelOption#CONNECT_TIMEOUT_MILLIS
      */
     Duration getConnectTimeout();
 
@@ -126,8 +125,6 @@ public interface ClientConfiguration {
      * Returns the {@link java.time.Duration socket timeout} which is typically applied as SO-timeout/read timeout.
      *
      * @see java.net.Socket#setSoTimeout(int)
-     * @see io.netty.handler.timeout.ReadTimeoutHandler
-     * @see io.netty.handler.timeout.WriteTimeoutHandler
      */
     Duration getSocketTimeout();
 
@@ -263,7 +260,6 @@ public interface ClientConfiguration {
          * @param timeout the timeout to use. Must not be {@literal null}.
          * @return the {@link TerminalClientConfigurationBuilder}
          * @see java.net.Socket#connect(SocketAddress, int)
-         * @see io.netty.channel.ChannelOption#CONNECT_TIMEOUT_MILLIS
          */
         TerminalClientConfigurationBuilder withConnectTimeout(Duration timeout);
 
@@ -284,8 +280,6 @@ public interface ClientConfiguration {
          * @param timeout the timeout to use. Must not be {@literal null}.
          * @return the {@link TerminalClientConfigurationBuilder}
          * @see java.net.Socket#setSoTimeout(int)
-         * @see io.netty.handler.timeout.ReadTimeoutHandler
-         * @see io.netty.handler.timeout.WriteTimeoutHandler
          */
         TerminalClientConfigurationBuilder withSocketTimeout(Duration timeout);
 

--- a/src/main/java/org/opensearch/data/client/orhlc/DocumentAdapters.java
+++ b/src/main/java/org/opensearch/data/client/orhlc/DocumentAdapters.java
@@ -49,7 +49,7 @@ import org.springframework.util.StringUtils;
 
 /**
  * Utility class to adapt {@link org.opensearch.action.get.GetResponse},
- * {@link org.opensearch.index.get.GetResult}, {@link org.opensearchs.action.get.MultiGetResponse}
+ * {@link org.opensearch.index.get.GetResult}, {@link org.opensearch.action.get.MultiGetResponse}
  * {@link org.opensearch.search.SearchHit}, {@link org.opensearch.common.document.DocumentField} to
  * {@link Document}.
  * @since 0.1

--- a/src/main/java/org/opensearch/data/client/orhlc/RestClients.java
+++ b/src/main/java/org/opensearch/data/client/orhlc/RestClients.java
@@ -238,7 +238,7 @@ public final class RestClients {
     }
 
     /**
-     * {@link org.springframework.data.elasticsearch.client.orhcl.ClientConfiguration.ClientConfigurationCallback} to configure
+     * {@link org.opensearch.data.client.orhlc.ClientConfiguration.ClientConfigurationCallback} to configure
      * the RestClient with a {@link HttpAsyncClientBuilder}
      */
     public interface RestClientConfigurationCallback


### PR DESCRIPTION
### Description

Running `./gradlew assemble` was failing. The errors reported were issues with Javadocs.

This PR corrects some Javadocs and removes references to Netty.

I plan to create a follow-on PR which includes Gradle `assemble` in the GitHub Actions to validate it continues to work. For now, I've tested via `./gradlew clean assemble` and have a successful build. Also `./gradlew clean build` now succeeds as well.

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
