### PR TITLE
Performs Gradle build in PR workflow

### DIFF
--- a/.github/workflows/main_and_pr_workflow.yml
+++ b/.github/workflows/main_and_pr_workflow.yml
@@ -27,4 +27,4 @@ jobs:
           distribution: 'temurin'
           cache: gradle
       - name: Build with Gradle
-        run: ./gradlew check -Psde.testcontainers.image-version=${{ matrix.entry.opensearch-version }}
+        run: ./gradlew build -Psde.testcontainers.image-version=${{ matrix.entry.opensearch-version }}


### PR DESCRIPTION
### Description

Performs the Gradle `build` instead of `check`. The `build` task depends on `check` and `assemble`, so this will run both workflows to ensure they continue to work .

### Issues Resolved


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
