### PR TITLE
Add an assemble job to the primary GitHub Actions workflow.

### DIFF
--- a/.github/workflows/main_and_pr_workflow.yml
+++ b/.github/workflows/main_and_pr_workflow.yml
@@ -5,17 +5,13 @@ on:
   pull_request:
     branches: [ main ]
 jobs:
-  build:
+  assemble:
     strategy:
       fail-fast: false
       matrix:
-        entry:
-          - { opensearch-version: 1.3.6, java-version: 17 }
-          - { opensearch-version: 1.3.6, java-version: 19 }
-          - { opensearch-version: 2.3.0, java-version: 17 }
-          - { opensearch-version: 2.3.0, java-version: 19 }
+        java-version: [17, 19]
         runs-on: [ubuntu-latest]
-    name: Build on ${{ matrix.runs-on }} with JDK ${{ matrix.entry.java-version }} against OpenSearch ${{ matrix.entry.opensearch-version }}
+    name: Assemble on ${{ matrix.runs-on }} with JDK ${{ matrix.entry.java-version }}
     runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout code
@@ -26,5 +22,29 @@ jobs:
           java-version: ${{ matrix.entry.java-version }}
           distribution: 'temurin'
           cache: gradle
-      - name: Build with Gradle
+      - name: Assemble with Gradle
+        run: ./gradlew assemble
+
+  check:
+    strategy:
+      fail-fast: false
+      matrix:
+        entry:
+          - { opensearch-version: 1.3.6, java-version: 17 }
+          - { opensearch-version: 1.3.6, java-version: 19 }
+          - { opensearch-version: 2.3.0, java-version: 17 }
+          - { opensearch-version: 2.3.0, java-version: 19 }
+        runs-on: [ubuntu-latest]
+    name: Check on ${{ matrix.runs-on }} with JDK ${{ matrix.entry.java-version }} against OpenSearch ${{ matrix.entry.opensearch-version }}
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up JDK ${{ matrix.entry.java-version }}
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.entry.java-version }}
+          distribution: 'temurin'
+          cache: gradle
+      - name: Check with Gradle
         run: ./gradlew check -Psde.testcontainers.image-version=${{ matrix.entry.opensearch-version }}

--- a/.github/workflows/main_and_pr_workflow.yml
+++ b/.github/workflows/main_and_pr_workflow.yml
@@ -11,15 +11,15 @@ jobs:
       matrix:
         java-version: [17, 19]
         runs-on: [ubuntu-latest]
-    name: Assemble on ${{ matrix.runs-on }} with JDK ${{ matrix.entry.java-version }}
+    name: Assemble on ${{ matrix.runs-on }} with JDK ${{ matrix.java-version }}
     runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Set up JDK ${{ matrix.entry.java-version }}
+      - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v3
         with:
-          java-version: ${{ matrix.entry.java-version }}
+          java-version: ${{ matrix.java-version }}
           distribution: 'temurin'
           cache: gradle
       - name: Assemble with Gradle


### PR DESCRIPTION
### Description

This PR runs the Gradle `assemble` task for pushes to ensure that it continues to run. This PR provides an alternative to #47 .

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
