### PR TITLE
Add release workflows

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -23,8 +23,7 @@ jobs:
           cache: gradle
       - name: Assemble with Gradle
         run: |
-          ./gradlew --no-daemon -Dbuild.snapshot=false publishPublishMavenPublicationToLocalRepoRepository
-          cd build && tar -czf ~/artifacts.tar.gz repository
+          ./gradlew --no-daemon -Dbuild.snapshot=false publishPublishMavenPublicationToLocalRepoRepository && tar -C build -cvf artifacts.tar.gz repository
       - name: Draft a release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,34 @@
+name: Release drafter
+
+# Push events to every tag not containing "/"
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  draft-a-release:
+    strategy:
+      fail-fast: false
+    name: Create release artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: 'temurin'
+          cache: gradle
+      - name: Assemble with Gradle
+        run: |
+          ./gradlew --no-daemon -Dbuild.snapshot=false publishPublishMavenPublicationToLocalRepoRepository
+          cd build && tar -czf artifacts.tar.gz repository
+      - name: Draft a release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          generate_release_notes: true
+          files: |
+            artifacts.tar.gz

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Assemble with Gradle
         run: |
           ./gradlew --no-daemon -Dbuild.snapshot=false publishPublishMavenPublicationToLocalRepoRepository
-          cd build && tar -czf artifacts.tar.gz repository
+          cd build && tar -czf ~/artifacts.tar.gz repository
       - name: Draft a release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -8,9 +8,7 @@ on:
 
 jobs:
   draft-a-release:
-    strategy:
-      fail-fast: false
-    name: Create release artifacts
+    name: Draft a release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -21,7 +19,7 @@ jobs:
           java-version: 17
           distribution: 'temurin'
           cache: gradle
-      - name: Assemble with Gradle
+      - name: Build with Gradle
         run: |
           ./gradlew --no-daemon -Dbuild.snapshot=false publishPublishMavenPublicationToLocalRepoRepository && tar -C build -cvf artifacts.tar.gz repository
       - name: Draft a release

--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -1,0 +1,16 @@
+lib = library(identifier: 'jenkins@1.5.1', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
+
+standardReleasePipelineWithGenericTrigger(
+    tokenIdCredential: 'jenkins-spring-data-opensearch-generic-webhook-token',
+    causeString: 'A tag was cut on opensearch-project/spring-data-opensearch repository causing this workflow to run',
+    downloadReleaseAsset: true,
+    publishRelease: false) {
+        publishToMaven(
+            signingArtifactsPath: "$WORKSPACE/repository/",
+            mavenArtifactsPath: "$WORKSPACE/repository/",
+            autoPublish: false
+        )
+    }


### PR DESCRIPTION
### Description
This PR adds below things:

* A GitHub action workflow that will be triggered when a tag is pushed to this repository. The workflow builds the release artifacts and creates a draft release with the built artifacts attached as artifacts.tar.gz in the draft release release.
* A jenkins workflow that is triggered based on above draft release. The workflow looks for artifacts.tar.gz, downloads it and then signs it and publishes it to Maven.

Currently, I have kept the autoPublish tab as `false` since this is the first release, we would like to see the staged artifacts before we hit release. Also taking artifacts down from maven is a pain. 

To-Do once the release is successful:
* Change the autoPublish flag to true
* Change the autoRelease tag to true

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/2846

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
