### PR TITLE
Bump jenkins lib version to 1.5.3 and set autoPublish to true

### DIFF
--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -1,4 +1,4 @@
-lib = library(identifier: 'jenkins@1.5.2', retriever: modernSCM([
+lib = library(identifier: 'jenkins@1.5.3', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))
@@ -11,6 +11,6 @@ standardReleasePipelineWithGenericTrigger(
         publishToMaven(
             signingArtifactsPath: "$WORKSPACE/repository/",
             mavenArtifactsPath: "$WORKSPACE/repository/",
-            autoPublish: false
+            autoPublish: true
         )
     }


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
The 1.5.3 version adds the missing JAVA_HOME args to docker container. Related PR: https://github.com/opensearch-project/opensearch-build-libraries/pull/105
Also setting autoPublish for maven to true since we tested this for last opensearch distribution release. 
### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
