### PR TITLE
Updating README.md with 0.1.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@ Includes integrated object mapping between documents and POJOs.
 ### Compatibility Matrix
 
 | Spring Data Release Train | Spring Data OpenSearch | Spring Data Elasticsearch | OpenSearch     | Spring Framework | Spring Boot |
+
 |---------------------------|------------------------|---------------------------|----------------|------------------|-------------|
-| 2022.0 (Turing)           | 0.1.x                  | 5.0.x                     | 1.3.6 / 2.3.0  | 6.0.x            | 3.0.x       |
+| 2022.0 (Turing)           | 0.2.x                  | 5.0.x                     | 1.3.6 / 2.4.1  | 6.0.x            | 3.0.x       |
+| 2022.0 (Turing)           | 0.1.0                  | 5.0.x                     | 1.3.6 / 2.4.1  | 6.0.x            | 3.0.x       |
 
 ### OpenSearch 2.x / 1.x client libraries
 
@@ -32,7 +34,7 @@ At the moment, Spring Data OpenSearch provides the possibility to use the `RestH
 <dependency>
 	<groupId>org.opensearch</groupId>
 	<artifactId>spring-data-opensearch</artifactId>
-	<version>${version}</version>
+	<version>0.1.0</version>
 </dependency>
 ```
 
@@ -42,7 +44,7 @@ To use Spring Boot 3.x auto configuration support:
 <dependency>
 	<groupId>org.opensearch</groupId>
 	<artifactId>spring-data-opensearch-starter</artifactId>
-	<version>${version}</version>
+	<version>0.1.0</version>
 </dependency>
 ```
 
@@ -52,7 +54,7 @@ To use Spring Boot 3.x auto configuration support for testing:
 <dependency>
 	<groupId>org.opensearch</groupId>
 	<artifactId>spring-data-opensearch-test-autoconfigure</artifactId>
-	<version>${version}</version>
+	<version>0.1.0</version>
 	<scope>test</scope>
 </dependency>
 ```
@@ -217,9 +219,10 @@ Add the Apache Maven dependency:
 <dependency>
   <groupId>org.opensearch.client</groupId>
   <artifactId>spring-data-opensearch</artifactId>
-  <version>${version}</version>
+  <version>0.1.0</version>
 </dependency>
 ```
+
 If you'd rather like the latest snapshots of the upcoming major version, use our Maven snapshot repository and declare the appropriate dependency version:
 
 ```xml
@@ -245,7 +248,7 @@ Add the Gradle dependency:
 ```groovy
 dependencies {
   ...
-  implementation "org.opensearch.client:spring-data-opensearch:${version}"
+  implementation "org.opensearch.client:spring-data-opensearch:0.1.0"
   ...
 }
 ```

--- a/spring-data-opensearch-test-autoconfigure/build.gradle.kts
+++ b/spring-data-opensearch-test-autoconfigure/build.gradle.kts
@@ -46,7 +46,7 @@ publishing {
       pom {
         name.set("Spring Data OpenSearch Spring Boot Autoconfiguration for Tests")
         packaging = "jar"
-        artifactId = "spring-data-opensearch-starter-test"
+        artifactId = "spring-data-opensearch-test-autoconfigure"
         description.set("Spring Boot autoconfigurations for Spring Data Implementation for OpenSearch to support testing")
         url.set("https://github.com/opensearch-project/spring-data-opensearch/")
         scm {

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=0.1.0
+version=0.2.0


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Spring Data OpenSearch 0.1.0 is released now: https://repo1.maven.org/maven2/org/opensearch/client/.
Updating README.md with 0.1.0 release and correcting `spring-data-opensearch-test-autoconfigure` artifact name

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
