### PR TITLE
Add 2PR approval to release workflow 

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -22,7 +22,7 @@ jobs:
           secret: ${{ github.TOKEN }}
           approvers: ${{ steps.get_data.outputs.approvers }}
           minimum-approvals: 1
-          issue-title: 'Release sprint-data-opensearch ${{ steps.get_data.outputs.version }}'
+          issue-title: 'Release spring-data-opensearch ${{ steps.get_data.outputs.version }}'
           issue-body: "Please approve or deny the release of spring-data-opensearch **TAG**: ${{ github.ref_name }}  **COMMIT**: ${{ github.sha }} **VERSION** : ${{ steps.get_data.outputs.version }} "
           exclude-workflow-initiator-as-approver: true
       - name: Set up JDK 17

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -13,6 +13,18 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+      - id: get_data
+        run: |
+          echo "approvers=$(cat .github/CODEOWNERS | grep @ | tr -d '*\n ' | sed 's/@/,/g' | sed 's/,//1')" >> $GITHUB_OUTPUT
+          echo "version=$(cat version.properties)" >> $GITHUB_OUTPUT
+      - uses: trstringer/manual-approval@v1
+        with:
+          secret: ${{ github.TOKEN }}
+          approvers: ${{ steps.get_data.outputs.approvers }}
+          minimum-approvals: 1
+          issue-title: 'Release sprint-data-opensearch ${{ steps.get_data.outputs.version }}'
+          issue-body: "Please approve or deny the release of spring-data-opensearch **TAG**: ${{ github.ref_name }}  **COMMIT**: ${{ github.sha }} **VERSION** : ${{ steps.get_data.outputs.version }} "
+          exclude-workflow-initiator-as-approver: true
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
### Description
This change retrieves the codeowner's list from .github/codeowners file and adds them as approvers for releasing spring-data-opensearch
Here is a sample issue that is created when this workflow runs: https://github.com/gaiksaya/spring-data-opensearch/issues/11
Once approved, the workflow continues to run as usual.
**_Note: This approval duration is subject to the broader 72 hours timeout for a workflow._**

### Issues Resolved
related https://github.com/opensearch-project/opensearch-build/issues/3111

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
