### PR TITLE
Dependency updates: Spring Framework 6.0.14, Spring Data Commons 3.1.6, Spring Data Elasticsearch 5.1.6, Jackson 2.16.0, Spotless 6.22.0

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,10 +14,10 @@ dependencyResolutionManagement {
     }
 
     create("springLibs") {
-      version("spring", "6.0.13")
+      version("spring", "6.0.14")
       version("spring-boot", "3.1.5")
-      library("data-commons", "org.springframework.data:spring-data-commons:3.1.5")
-      library("data-elasticsearch", "org.springframework.data:spring-data-elasticsearch:5.1.5")
+      library("data-commons", "org.springframework.data:spring-data-commons:3.1.6")
+      library("data-elasticsearch", "org.springframework.data:spring-data-elasticsearch:5.1.6")
       library("web", "org.springframework", "spring-web").versionRef("spring")
       library("context", "org.springframework", "spring-context").versionRef("spring")
       library("tx", "org.springframework", "spring-tx").versionRef("spring")
@@ -38,13 +38,13 @@ dependencyResolutionManagement {
     }
     
     create("jacksonLibs") {
-      version("jackson", "2.15.3")
+      version("jackson", "2.16.0")
       library("core", "com.fasterxml.jackson.core", "jackson-core").versionRef("jackson")
       library("databind", "com.fasterxml.jackson.core", "jackson-databind").versionRef("jackson")
     }
     
     create("pluginLibs") {
-      version("spotless", "6.18.0")
+      version("spotless", "6.22.0")
       version("editorconfig", "0.0.3")
       version("release", "3.0.2")
       plugin("editorconfig", "org.ec4j.editorconfig").versionRef("editorconfig")


### PR DESCRIPTION
### Description
Dependency updates: Spring Framework 6.0.14, Spring Data Commons 3.1.6, Spring Data Elasticsearch 5.1.6, Jackson 2.16.0, Spotless 6.22.0

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
