### PR TITLE
Logback 1.4.12 in the Spring Boot example to fix CVE-2023-6378

### DIFF
--- a/spring-data-opensearch-examples/spring-boot-gradle/build.gradle.kts
+++ b/spring-data-opensearch-examples/spring-boot-gradle/build.gradle.kts
@@ -32,6 +32,15 @@ dependencies {
   testImplementation(springLibs.boot.test.autoconfigure)
   testImplementation(opensearchLibs.testcontainers)
   testImplementation(project(":spring-data-opensearch-test-autoconfigure"))
+
+  constraints {
+    implementation("ch.qos.logback:logback-classic") {
+      version {
+        require("1.4.12")
+      }
+      because("Fixes CVE-2023-6378")
+    }
+  }
 }
 
 description = "Spring Data OpenSearch Spring Boot Example Project"


### PR DESCRIPTION
### Description

Require Logback 1.4.12 in the Spring Boot example to fix CVE-2023-6378.

### Issues Resolved

Resolves #199

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
