### PR TITLE
Update build to use Gradle 8.5 version catalogs

### DIFF
--- a/buildSrc/src/main/kotlin/java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-conventions.gradle.kts
@@ -48,16 +48,28 @@ if (!buildVersion.equals(tagVersion)) {
 version = buildVersion 
 java.sourceCompatibility = JavaVersion.VERSION_17
 
-// See please https://github.com/gradle/gradle/issues/15383
-val catalogs = extensions.getByType<VersionCatalogsExtension>()
-val jupiter = catalogs.named("libs").findVersion("jupiter").get().requiredVersion
+versionCatalogs
+  .named("libs")
+  .findLibrary("jupiter")
+  .ifPresent { jupiter -> 
+    dependencies { 
+      testImplementation(jupiter) 
+    }
+  }
+
+versionCatalogs
+  .named("libs")
+  .findLibrary("jupiter-params")
+  .ifPresent { jupiterParams -> 
+    dependencies { 
+      testImplementation(jupiterParams) 
+    }
+  }
 
 dependencies {
-  testImplementation("org.testcontainers:testcontainers:1.19.1")
-  testImplementation("org.testcontainers:junit-jupiter:1.19.1")
+  testImplementation("org.testcontainers:testcontainers:1.19.3")
+  testImplementation("org.testcontainers:junit-jupiter:1.19.3")
   testImplementation("org.mockito:mockito-junit-jupiter:5.6.0")
-  testImplementation("org.junit.jupiter:junit-jupiter:${jupiter}")
-  testImplementation("org.junit.jupiter:junit-jupiter-params:${jupiter}")
   testImplementation("org.assertj:assertj-core:3.24.2")
   testImplementation("ch.qos.logback:logback-classic:1.4.12")
 }


### PR DESCRIPTION
### Description
Update build to use Gradle 8.5 version catalogs

### Issues Resolved
See please https://docs.gradle.org/8.5/release-notes.html#catalog-precompiled

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
