### PR TITLE
Add refresh policy setting when creating DeleteByQueryRequest

### DIFF
--- a/spring-data-opensearch/src/main/java/org/opensearch/data/client/orhlc/OpenSearchRestTemplate.java
+++ b/spring-data-opensearch/src/main/java/org/opensearch/data/client/orhlc/OpenSearchRestTemplate.java
@@ -226,7 +226,7 @@ public class OpenSearchRestTemplate extends AbstractElasticsearchTemplate {
     @Override
     public ByQueryResponse delete(Query query, Class<?> clazz, IndexCoordinates index) {
         DeleteByQueryRequest deleteByQueryRequest =
-                requestFactory.deleteByQueryRequest(query, routingResolver.getRouting(), clazz, index);
+                requestFactory.deleteByQueryRequest(query, routingResolver.getRouting(), clazz, index, this.refreshPolicy);
         return ResponseConverter.byQueryResponseOf(
                 execute(client -> client.deleteByQuery(deleteByQueryRequest, RequestOptions.DEFAULT)));
     }

--- a/spring-data-opensearch/src/main/java/org/opensearch/data/client/orhlc/RequestFactory.java
+++ b/spring-data-opensearch/src/main/java/org/opensearch/data/client/orhlc/RequestFactory.java
@@ -529,12 +529,12 @@ class RequestFactory {
 
     // region delete
     public DeleteByQueryRequest deleteByQueryRequest(
-            Query query, @Nullable String routing, Class<?> clazz, IndexCoordinates index) {
+            Query query, @Nullable String routing, Class<?> clazz, IndexCoordinates index, RefreshPolicy refreshPolicy) {
         SearchRequest searchRequest = searchRequest(query, routing, clazz, index);
         DeleteByQueryRequest deleteByQueryRequest = new DeleteByQueryRequest(index.getIndexNames()) //
                 .setQuery(searchRequest.source().query()) //
                 .setAbortOnVersionConflict(false) //
-                .setRefresh(true);
+                .setRefresh(deleteByQueryRefresh(refreshPolicy));
 
         if (query.isLimiting()) {
             // noinspection ConstantConditions
@@ -1365,6 +1365,17 @@ class RequestFactory {
         }
 
         return null;
+    }
+
+    static boolean deleteByQueryRefresh(@Nullable RefreshPolicy refreshPolicy) {
+        if (refreshPolicy == null) {
+            return false;
+        } else {
+            return switch (refreshPolicy) {
+                case IMMEDIATE -> true;
+                case WAIT_UNTIL, NONE -> false;
+            };
+        }
     }
 
     // endregion

--- a/spring-data-opensearch/src/test/java/org/opensearch/data/client/orhlc/RequestFactoryTests.java
+++ b/spring-data-opensearch/src/test/java/org/opensearch/data/client/orhlc/RequestFactoryTests.java
@@ -38,6 +38,7 @@ import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.functionscore.FunctionScoreQueryBuilder;
 import org.opensearch.index.query.functionscore.FunctionScoreQueryBuilder.FilterFunctionBuilder;
 import org.opensearch.index.query.functionscore.GaussDecayFunctionBuilder;
+import org.opensearch.index.reindex.DeleteByQueryRequest;
 import org.opensearch.search.fetch.subphase.FetchSourceContext;
 import org.springframework.core.convert.support.GenericConversionService;
 import org.springframework.data.annotation.Id;
@@ -46,6 +47,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.core.RefreshPolicy;
 import org.springframework.data.elasticsearch.core.convert.MappingElasticsearchConverter;
 import org.springframework.data.elasticsearch.core.geo.GeoPoint;
 import org.springframework.data.elasticsearch.core.index.AliasAction;
@@ -1063,6 +1065,45 @@ class RequestFactoryTests {
         UpdateRequest updateRequest = requestFactory.updateRequest(updateQuery, IndexCoordinates.of(methodIndexName));
 
         assertThat(updateRequest.index()).isEqualTo(methodIndexName);
+    }
+
+    @Test
+    void shouldSetRefreshTrueIfRefreshPolicyIsImmediateInDeleteByQuery() {
+        String methodIndexName = "method-index-name";
+        Query searchQuery = new NativeSearchQueryBuilder()
+            .withQuery(matchAllQuery())
+            .build();
+
+        DeleteByQueryRequest deleteByQueryRequest = requestFactory.deleteByQueryRequest(searchQuery, null, Person.class,
+                                                                                        IndexCoordinates.of(methodIndexName), RefreshPolicy.IMMEDIATE);
+
+        assertThat(deleteByQueryRequest.isRefresh()).isTrue();
+    }
+
+    @Test
+    void shouldSetRefreshFalseIfRefreshPolicyIsNoneInDeleteByQuery() {
+        String methodIndexName = "method-index-name";
+        Query searchQuery = new NativeSearchQueryBuilder()
+            .withQuery(matchAllQuery())
+            .build();
+
+        DeleteByQueryRequest deleteByQueryRequest = requestFactory.deleteByQueryRequest(searchQuery, null, Person.class,
+                                                                                        IndexCoordinates.of(methodIndexName), RefreshPolicy.NONE);
+
+        assertThat(deleteByQueryRequest.isRefresh()).isFalse();
+    }
+
+    @Test
+    void shouldSetRefreshFalseIfRefreshPolicyIsWaitUntilInDeleteByQuery() {
+        String methodIndexName = "method-index-name";
+        Query searchQuery = new NativeSearchQueryBuilder()
+            .withQuery(matchAllQuery())
+            .build();
+
+        DeleteByQueryRequest deleteByQueryRequest = requestFactory.deleteByQueryRequest(searchQuery, null, Person.class,
+                                                                                        IndexCoordinates.of(methodIndexName), RefreshPolicy.WAIT_UNTIL);
+
+        assertThat(deleteByQueryRequest.isRefresh()).isFalse();
     }
 
     // region entities


### PR DESCRIPTION
### Description
Add refresh policy setting when creating DeleteByQueryRequest
(Is the wait_for option among the refresh options of Delete by query supported? An error occurs when making an actual request. see please opensearch-project/OpenSearch#12687)
### Issues Resolved
See please #244

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
