### PR TITLE
Remove redundant annotation @ResponseBody

### DIFF
--- a/spring-data-opensearch-examples/spring-boot-gradle/src/main/java/org/opensearch/data/example/rest/MarketplaceRestController.java
+++ b/spring-data-opensearch-examples/spring-boot-gradle/src/main/java/org/opensearch/data/example/rest/MarketplaceRestController.java
@@ -26,7 +26,6 @@ public class MarketplaceRestController {
     }
 
     @GetMapping(value = "/search", produces = MediaType.APPLICATION_JSON_VALUE)
-    @ResponseBody
     public List<Product> search(
             @RequestParam(value = "name", required = false, defaultValue = "") String name,
             @RequestParam(value = "price", required = false, defaultValue = "0.0") BigDecimal price) {

--- a/spring-data-opensearch-examples/spring-boot-gradle/src/main/java/org/opensearch/data/example/rest/MarketplaceRestController.java
+++ b/spring-data-opensearch-examples/spring-boot-gradle/src/main/java/org/opensearch/data/example/rest/MarketplaceRestController.java
@@ -13,7 +13,6 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController


### PR DESCRIPTION
### Description
`@Responsebody` on method, already defined at `@RestController` annotation

### Issues Resolved
n/a

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
