### PR TITLE
Dependency updates: Jackson 2.17.1, Opensearch Java 2.10.4

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -31,7 +31,7 @@ dependencyResolutionManagement {
     
     create("opensearchLibs") {
       version("opensearch", "2.14.0")
-      library("java-client", "org.opensearch.client:opensearch-java:2.10.3")
+      library("java-client", "org.opensearch.client:opensearch-java:2.10.4")
       library("client", "org.opensearch.client", "opensearch-rest-client").versionRef("opensearch")
       library("high-level-client", "org.opensearch.client", "opensearch-rest-high-level-client").versionRef("opensearch")
       library("sniffer", "org.opensearch.client", "opensearch-rest-client-sniffer").versionRef("opensearch")
@@ -39,7 +39,7 @@ dependencyResolutionManagement {
     }
     
     create("jacksonLibs") {
-      version("jackson", "2.17.0")
+      version("jackson", "2.17.1")
       library("core", "com.fasterxml.jackson.core", "jackson-core").versionRef("jackson")
       library("databind", "com.fasterxml.jackson.core", "jackson-databind").versionRef("jackson")
     }


### PR DESCRIPTION
### Description
Dependency updates: Jackson 2.17.1, Opensearch Java 2.10.4

### Issues Resolved
N/A

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
