### PR TITLE
Update to Testcontainers 1.20.0 and OpenSearch Testcontainers 2.1.0

### DIFF
--- a/buildSrc/src/main/kotlin/java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-conventions.gradle.kts
@@ -67,8 +67,8 @@ versionCatalogs
   }
 
 dependencies {
-  testImplementation("org.testcontainers:testcontainers:1.19.8")
-  testImplementation("org.testcontainers:junit-jupiter:1.19.8")
+  testImplementation("org.testcontainers:testcontainers:1.20.0")
+  testImplementation("org.testcontainers:junit-jupiter:1.20.0")
   testImplementation("org.mockito:mockito-junit-jupiter:5.6.0")
   testImplementation("org.assertj:assertj-core:3.24.2")
   testImplementation("ch.qos.logback:logback-classic:1.4.14")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -35,7 +35,7 @@ dependencyResolutionManagement {
       library("client", "org.opensearch.client", "opensearch-rest-client").versionRef("opensearch")
       library("high-level-client", "org.opensearch.client", "opensearch-rest-high-level-client").versionRef("opensearch")
       library("sniffer", "org.opensearch.client", "opensearch-rest-client-sniffer").versionRef("opensearch")
-      library("testcontainers", "org.opensearch:opensearch-testcontainers:2.0.1") 
+      library("testcontainers", "org.opensearch:opensearch-testcontainers:2.1.0") 
     }
     
     create("jacksonLibs") {


### PR DESCRIPTION
### Description
Update to Testcontainers 1.20.0 and OpenSearch Testcontainers 2.1.0

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
