### PR TITLE
Update README.md and fix the opensearch-rest-client dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ To switch over to `OpenSearchClient`, the `opensearch-rest-high-level-client` de
 <dependency>
 	<groupId>org.opensearch.client</groupId>
 	<artifactId>opensearch-java</artifactId>
-	<version>2.10.4</version>
+	<version>2.11.1</version>
 </dependency>
 ```
 
@@ -113,7 +113,7 @@ To use Spring Boot 3.x auto configuration support:
 <dependency>
 	<groupId>org.opensearch.client</groupId>
 	<artifactId>opensearch-java</artifactId>
-	<version>2.10.4</version>
+	<version>2.11.1</version>
 </dependency>
 ```
 
@@ -136,7 +136,7 @@ To use Spring Boot 3.x auto configuration support for testing:
 <dependency>
 	<groupId>org.opensearch.client</groupId>
 	<artifactId>opensearch-java</artifactId>
-	<version>2.10.4</version>
+	<version>2.11.1</version>
 </dependency>
 ```
 

--- a/spring-data-opensearch/build.gradle.kts
+++ b/spring-data-opensearch/build.gradle.kts
@@ -23,6 +23,10 @@ dependencies {
     exclude("co.elastic.clients", "*")
     exclude("org.elasticsearch.client", "*")
   }
+  api(opensearchLibs.client) {
+    exclude("commons-logging", "commons-logging")
+    exclude("org.slf4j", "slf4j-api")
+  }
   api(opensearchLibs.high.level.client) {
     exclude("commons-logging", "commons-logging")
   }


### PR DESCRIPTION
### Description
Update README.md and fix the `opensearch-rest-client` dependencies. We always need the `opensearch-rest-client`  to be present since `OpenSearchClient`'s default transport is `RestClientTransport`.

### Issues Resolved
Coming from https://github.com/opensearch-project/spring-data-opensearch/issues/267#issuecomment-2239524472

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
