### PR TITLE
Add Service Connection support from Testcontainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,16 @@ public class MarketplaceRepositoryIntegrationTests {
 }
 ```
 
+There is also support for [Testcontainers Service Connections](https://docs.spring.io/spring-boot/reference/testing/testcontainers.html#testing.testcontainers.service-connections) 
+
+```java
+@Container
+@ServiceConnection
+static final OpenSearchContainer<?> container = new OpenSearchContainer<>("opensearchproject/opensearch:2.15.0");
+```
+
+So, the client will take values from the `OpenSearchContainer` configuration.
+
 ### Apache Maven configuration
 
 Add the Apache Maven dependency:

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,6 +26,7 @@ dependencyResolutionManagement {
       library("boot-autoconfigure", "org.springframework.boot", "spring-boot-autoconfigure").versionRef("spring-boot")
       library("boot-test", "org.springframework.boot", "spring-boot-test").versionRef("spring-boot")
       library("boot-test-autoconfigure", "org.springframework.boot", "spring-boot-test-autoconfigure").versionRef("spring-boot")
+      library("boot-testcontainers", "org.springframework.boot", "spring-boot-testcontainers").versionRef("spring-boot")
       plugin("spring-boot", "org.springframework.boot").versionRef("spring-boot")
     }
     
@@ -82,5 +83,6 @@ dependencyResolutionManagement {
 include("spring-data-opensearch")
 include("spring-data-opensearch-starter")
 include("spring-data-opensearch-test-autoconfigure")
+include("spring-data-opensearch-testcontainers")
 include("spring-data-opensearch-examples:spring-boot-gradle")
 include("spring-data-opensearch-examples:spring-boot-java-client-gradle")

--- a/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/OpenSearchConnectionDetails.java
+++ b/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/OpenSearchConnectionDetails.java
@@ -16,4 +16,8 @@ public interface OpenSearchConnectionDetails extends ConnectionDetails {
 
     String getPassword();
 
+    default String getPathPrefix() {
+        return null;
+    }
+
 }

--- a/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/OpenSearchConnectionDetails.java
+++ b/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/OpenSearchConnectionDetails.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright OpenSearch Contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.spring.boot.autoconfigure;
+
+import java.util.List;
+import org.springframework.boot.autoconfigure.service.connection.ConnectionDetails;
+
+public interface OpenSearchConnectionDetails extends ConnectionDetails {
+
+    List<String> getUris();
+
+    String getUsername();
+
+    String getPassword();
+
+}

--- a/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/OpenSearchRestClientAutoConfiguration.java
+++ b/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/OpenSearchRestClientAutoConfiguration.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.spring.boot.autoconfigure;
 
+import java.util.List;
 import org.opensearch.client.RestClientBuilder;
 import org.opensearch.spring.boot.autoconfigure.OpenSearchRestClientConfigurations.RestClientBuilderConfiguration;
 import org.opensearch.spring.boot.autoconfigure.OpenSearchRestClientConfigurations.RestClientConfiguration;
@@ -12,7 +13,9 @@ import org.opensearch.spring.boot.autoconfigure.OpenSearchRestClientConfiguratio
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
 /**
@@ -25,4 +28,36 @@ import org.springframework.context.annotation.Import;
 @ConditionalOnClass(RestClientBuilder.class)
 @EnableConfigurationProperties(OpenSearchProperties.class)
 @Import({RestClientBuilderConfiguration.class, RestClientConfiguration.class, RestClientSnifferConfiguration.class})
-public class OpenSearchRestClientAutoConfiguration {}
+public class OpenSearchRestClientAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(OpenSearchConnectionDetails.class)
+    PropertiesOpenSearchConnectionDetails openSearchConnectionDetails(OpenSearchProperties properties) {
+        return new PropertiesOpenSearchConnectionDetails(properties);
+    }
+
+    static class PropertiesOpenSearchConnectionDetails implements OpenSearchConnectionDetails {
+
+        private final OpenSearchProperties properties;
+
+        public PropertiesOpenSearchConnectionDetails(OpenSearchProperties properties) {
+            this.properties = properties;
+        }
+
+        @Override
+        public List<String> getUris() {
+            return this.properties.getUris();
+        }
+
+        @Override
+        public String getUsername() {
+            return this.properties.getUsername();
+        }
+
+        @Override
+        public String getPassword() {
+            return this.properties.getPassword();
+        }
+    }
+
+}

--- a/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/OpenSearchRestClientAutoConfiguration.java
+++ b/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/OpenSearchRestClientAutoConfiguration.java
@@ -58,6 +58,11 @@ public class OpenSearchRestClientAutoConfiguration {
         public String getPassword() {
             return this.properties.getPassword();
         }
+
+        @Override
+        public String getPathPrefix() {
+            return this.properties.getPathPrefix();
+        }
     }
 
 }

--- a/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/OpenSearchRestClientAutoConfiguration.java
+++ b/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/OpenSearchRestClientAutoConfiguration.java
@@ -32,7 +32,7 @@ public class OpenSearchRestClientAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean(OpenSearchConnectionDetails.class)
-    PropertiesOpenSearchConnectionDetails openSearchConnectionDetails(OpenSearchProperties properties) {
+    OpenSearchConnectionDetails openSearchConnectionDetails(OpenSearchProperties properties) {
         return new PropertiesOpenSearchConnectionDetails(properties);
     }
 

--- a/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/OpenSearchRestClientAutoConfiguration.java
+++ b/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/OpenSearchRestClientAutoConfiguration.java
@@ -40,7 +40,7 @@ public class OpenSearchRestClientAutoConfiguration {
 
         private final OpenSearchProperties properties;
 
-        public PropertiesOpenSearchConnectionDetails(OpenSearchProperties properties) {
+        PropertiesOpenSearchConnectionDetails(OpenSearchProperties properties) {
             this.properties = properties;
         }
 

--- a/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/OpenSearchRestClientConfigurations.java
+++ b/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/OpenSearchRestClientConfigurations.java
@@ -68,8 +68,8 @@ class OpenSearchRestClientConfigurations {
                 builderCustomizers.orderedStream().forEach((customizer) -> customizer.customize(requestConfigBuilder));
                 return requestConfigBuilder;
             });
-            if (this.properties.getPathPrefix() != null) {
-                builder.setPathPrefix(this.properties.getPathPrefix());
+            if (this.connectionDetails.getPathPrefix() != null) {
+                builder.setPathPrefix(this.connectionDetails.getPathPrefix());
             }
             builderCustomizers.orderedStream().forEach((customizer) -> customizer.customize(builder));
             return builder;

--- a/spring-data-opensearch-testcontainers/build.gradle.kts
+++ b/spring-data-opensearch-testcontainers/build.gradle.kts
@@ -1,0 +1,78 @@
+/*
+ * Copyright OpenSearch Contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+plugins {
+  alias(pluginLibs.plugins.spotless)
+  alias(pluginLibs.plugins.editorconfig)
+  id("java-conventions")
+}
+
+buildscript {
+  dependencies {
+    classpath(pluginLibs.editorconfig)
+    classpath(pluginLibs.spotless)
+  }
+}
+
+dependencies {
+  implementation(project(":spring-data-opensearch-starter"))
+  implementation(libs.jupiter)
+  implementation(springLibs.boot.test.autoconfigure)
+  implementation(springLibs.boot.testcontainers)
+  implementation(springLibs.test)
+  implementation(opensearchLibs.testcontainers)
+}
+
+description = "Spring Data OpenSearch Spring Boot Testcontainers"
+
+spotless {
+  java {
+    target("src/main/java/**/*.java", "src/test/java/org/opensearch/**/*.java")
+
+    trimTrailingWhitespace()
+    indentWithSpaces()
+    endWithNewline()
+
+    removeUnusedImports()
+    importOrder()
+  }
+}
+
+publishing {
+  publications {
+    create<MavenPublication>("publishMaven") {
+      from(components["java"])
+      pom {
+        name.set("Spring Data OpenSearch Spring Boot Testcontainers")
+        packaging = "jar"
+        artifactId = "spring-data-opensearch-testcontainers"
+        description.set("Spring Boot autoconfigurations for Spring Data Implementation for OpenSearch to support testing")
+        url.set("https://github.com/opensearch-project/spring-data-opensearch/")
+        scm {
+          connection.set("scm:git@github.com:opensearch-project/spring-data-opensearch.git")
+          developerConnection.set("scm:git@github.com:opensearch-project/spring-data-opensearch.git")
+          url.set("git@github.com:opensearch-project/spring-data-opensearch.git")
+        }
+        licenses {
+          license {
+            name.set("The Apache License, Version 2.0")
+            url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+          }
+        }
+        developers {
+          developer {
+            name.set("opensearch-project")
+            url.set("https://www.opensearch.org")
+            inceptionYear.set("2022")
+          }
+        }
+      }
+    }
+  }
+}
+
+tasks.withType<Javadoc>() {
+  options.memberLevel = JavadocMemberLevel.PACKAGE
+}

--- a/spring-data-opensearch-testcontainers/src/main/java/org/opensearch/spring/boot/testcontainers/service/connection/OpenSearchContainerConnectionDetailsFactory.java
+++ b/spring-data-opensearch-testcontainers/src/main/java/org/opensearch/spring/boot/testcontainers/service/connection/OpenSearchContainerConnectionDetailsFactory.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright OpenSearch Contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.spring.boot.testcontainers.service.connection;
+
+import java.util.List;
+import org.opensearch.spring.boot.autoconfigure.OpenSearchConnectionDetails;
+import org.opensearch.testcontainers.OpensearchContainer;
+import org.springframework.boot.testcontainers.service.connection.ContainerConnectionDetailsFactory;
+import org.springframework.boot.testcontainers.service.connection.ContainerConnectionSource;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.util.StringUtils;
+
+/**
+ * {@link ContainerConnectionDetailsFactory} to create {@link OpenSearchConnectionDetails}
+ * from a {@link ServiceConnection @ServiceConnection}-annotated
+ * {@link OpensearchContainer}.
+ */
+class OpenSearchContainerConnectionDetailsFactory
+    extends ContainerConnectionDetailsFactory<OpensearchContainer<?>, OpenSearchConnectionDetails> {
+
+    @Override
+    protected OpenSearchConnectionDetails getContainerConnectionDetails(ContainerConnectionSource<OpensearchContainer<?>> source) {
+        return new OpenSearchContainerConnectionDetails(source);
+    }
+
+    private static final class OpenSearchContainerConnectionDetails
+            extends ContainerConnectionDetails<OpensearchContainer<?>> implements OpenSearchConnectionDetails {
+
+        private OpenSearchContainerConnectionDetails(ContainerConnectionSource<OpensearchContainer<?>> source) {
+            super(source);
+        }
+
+        @Override
+        public List<String> getUris() {
+            return List.of(getContainer().getHttpHostAddress());
+        }
+
+        @Override
+        public String getUsername() {
+            return isSecured(getContainer()) ? getContainer().getUsername() : null;
+        }
+
+        @Override
+        public String getPassword() {
+            return getPassword(getContainer());
+        }
+
+        private static boolean isSecured(OpensearchContainer<?> container) {
+            return container.isSecurityEnabled();
+        }
+
+        private static String getPassword(OpensearchContainer<?> container) {
+            if (isSecured(container)) {
+                String initialAdminPassword = container.getEnvMap().get("OPENSEARCH_INITIAL_ADMIN_PASSWORD");
+                if (StringUtils.hasText(initialAdminPassword)) {
+                    return initialAdminPassword;
+                }
+                return container.getPassword();
+            }
+            return null;
+        }
+    }
+}

--- a/spring-data-opensearch-testcontainers/src/main/resources/META-INF/spring.factories
+++ b/spring-data-opensearch-testcontainers/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.service.connection.ConnectionDetailsFactory=\
+org.opensearch.spring.boot.testcontainers.service.connection.OpenSearchContainerConnectionDetailsFactory

--- a/spring-data-opensearch-testcontainers/src/test/java/org/opensearch/spring/boot/testcontainers/service/connection/OpenSearchContainerConnectionDetailsFactoryIntegrationTests.java
+++ b/spring-data-opensearch-testcontainers/src/test/java/org/opensearch/spring/boot/testcontainers/service/connection/OpenSearchContainerConnectionDetailsFactoryIntegrationTests.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright OpenSearch Contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.spring.boot.testcontainers.service.connection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Duration;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.client.RestClient;
+import org.opensearch.spring.boot.autoconfigure.OpenSearchRestClientAutoConfiguration;
+import org.opensearch.testcontainers.OpensearchContainer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Tag("integration-test")
+@SpringJUnitConfig
+@Testcontainers
+class OpenSearchContainerConnectionDetailsFactoryIntegrationTests {
+
+    @Container
+    @ServiceConnection
+    static final OpensearchContainer<?> opensearch = new OpensearchContainer<>("opensearchproject/opensearch:2.15.0")
+            .withStartupAttempts(5)
+            .withStartupTimeout(Duration.ofMinutes(10));
+
+    @Autowired
+    private RestClient restClient;
+
+    @Test
+    void restClientOpensearchNodeVersion() throws IOException {
+        final Request request = new Request("GET", "/");
+        final Response response = restClient.performRequest(request);
+        try (InputStream input = response.getEntity().getContent()) {
+            JsonNode result = new ObjectMapper().readTree(input);
+            assertThat(result.path("version").path("number").asText())
+                    .isEqualTo("2.15.0");
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @ImportAutoConfiguration(OpenSearchRestClientAutoConfiguration.class)
+    static class TestConfiguration {
+
+    }
+}

--- a/spring-data-opensearch-testcontainers/src/test/java/org/opensearch/spring/boot/testcontainers/service/connection/SecureOpenSearchContainerConnectionDetailsFactoryIntegrationTests.java
+++ b/spring-data-opensearch-testcontainers/src/test/java/org/opensearch/spring/boot/testcontainers/service/connection/SecureOpenSearchContainerConnectionDetailsFactoryIntegrationTests.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright OpenSearch Contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.spring.boot.testcontainers.service.connection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import javax.net.ssl.SSLContext;
+import org.apache.http.conn.ssl.TrustAllStrategy;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.apache.http.ssl.SSLContextBuilder;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.client.RestClient;
+import org.opensearch.client.RestClientBuilder;
+import org.opensearch.spring.boot.autoconfigure.OpenSearchRestClientAutoConfiguration;
+import org.opensearch.spring.boot.autoconfigure.RestClientBuilderCustomizer;
+import org.opensearch.testcontainers.OpensearchContainer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Tag("integration-test")
+@SpringJUnitConfig
+@Testcontainers
+class SecureOpenSearchContainerConnectionDetailsFactoryIntegrationTests {
+
+    @Container
+    @ServiceConnection
+    static final OpensearchContainer<?> opensearch = new OpensearchContainer<>("opensearchproject/opensearch:2.15.0")
+            .withSecurityEnabled()
+            .withEnv("OPENSEARCH_INITIAL_ADMIN_PASSWORD", "D3v3l0p-ment");
+
+    @Autowired
+    private RestClient restClient;
+
+    @Test
+    void restClientOpensearchNodeVersion() throws IOException {
+        final Request request = new Request("GET", "/");
+        final Response response = restClient.performRequest(request);
+        try (InputStream input = response.getEntity().getContent()) {
+            JsonNode result = new ObjectMapper().readTree(input);
+            assertThat(result.path("version").path("number").asText())
+                    .isEqualTo("2.15.0");
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @ImportAutoConfiguration(OpenSearchRestClientAutoConfiguration.class)
+    static class TestConfiguration {
+
+        @Bean
+        RestClientBuilderCustomizer customizer() {
+            return new RestClientBuilderCustomizer() {
+
+                @Override
+                public void customize(RestClientBuilder builder) {
+
+                }
+
+                @Override
+                public void customize(HttpAsyncClientBuilder builder) {
+                    final SSLContext sslcontext;
+                    try {
+                        sslcontext = SSLContextBuilder.create()
+                                .loadTrustMaterial(null, new TrustAllStrategy())
+                                .build();
+                    } catch (NoSuchAlgorithmException | KeyManagementException | KeyStoreException e) {
+                        throw new RuntimeException(e);
+                    }
+                    builder.setSSLContext(sslcontext);
+                }
+            };
+        }
+
+    }
+}

--- a/spring-data-opensearch-testcontainers/src/test/resources/logback-test.xml
+++ b/spring-data-opensearch-testcontainers/src/test/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="org.testcontainers" level="INFO"/>
+</configuration>


### PR DESCRIPTION
### Description

* Add `OpenSearchConnectionDetails`
* Add `PropertiesOpenSearchConnectionDetails` implementation
* Add new module `spring-data-opensearch-testcontainers`
* Add `OpenSearchContainerConnectionDetails` from `OpenSearchContainer`

Previously, `opensearch.uris`, `opensearch.username` and `opensearch.password` had to be declared via `DynamicPropertySource`. Since 3.1, Spring Boot added support for Service Connections, so, nowadays, just adding `@ServiceConnection` to `OpenSearchContainer`, the properties will take values from the container.

### Issues Resolved

N/A

### Check List
- [x] New functionality includes testing.
- [x] All tests pass
- [x] New functionality has been documented.
- [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
