### PR TITLE
Add Service Connection support from Docker Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,11 @@ public class MarketplaceRepositoryIntegrationTests {
 }
 ```
 
-There is also support for [Testcontainers Service Connections](https://docs.spring.io/spring-boot/reference/testing/testcontainers.html#testing.testcontainers.service-connections) 
+### Spring Boot Service Connection
+
+#### Testcontainers Service Connections
+
+See https://docs.spring.io/spring-boot/reference/testing/testcontainers.html#testing.testcontainers.service-connections 
 
 ```java
 @Container
@@ -301,6 +305,12 @@ static final OpenSearchContainer<?> container = new OpenSearchContainer<>("opens
 ```
 
 So, the client will take values from the `OpenSearchContainer` configuration.
+
+#### Docker Compose Service Connections
+
+See https://docs.spring.io/spring-boot/reference/features/dev-services.html#features.dev-services.docker-compose.service-connections
+
+Support image `opensearchproject/opensearch`.
 
 ### Apache Maven configuration
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,6 +24,7 @@ dependencyResolutionManagement {
       library("test", "org.springframework", "spring-test").versionRef("spring")
       library("boot-web", "org.springframework.boot", "spring-boot-starter-web").versionRef("spring-boot")
       library("boot-autoconfigure", "org.springframework.boot", "spring-boot-autoconfigure").versionRef("spring-boot")
+      library("boot-docker-compose", "org.springframework.boot", "spring-boot-docker-compose").versionRef("spring-boot")
       library("boot-test", "org.springframework.boot", "spring-boot-test").versionRef("spring-boot")
       library("boot-test-autoconfigure", "org.springframework.boot", "spring-boot-test-autoconfigure").versionRef("spring-boot")
       library("boot-testcontainers", "org.springframework.boot", "spring-boot-testcontainers").versionRef("spring-boot")
@@ -81,6 +82,7 @@ dependencyResolutionManagement {
 }
 
 include("spring-data-opensearch")
+include("spring-data-opensearch-docker-compose")
 include("spring-data-opensearch-starter")
 include("spring-data-opensearch-test-autoconfigure")
 include("spring-data-opensearch-testcontainers")

--- a/spring-data-opensearch-docker-compose/build.gradle.kts
+++ b/spring-data-opensearch-docker-compose/build.gradle.kts
@@ -1,0 +1,85 @@
+/*
+ * Copyright OpenSearch Contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+plugins {
+  alias(pluginLibs.plugins.spotless)
+  alias(pluginLibs.plugins.editorconfig)
+  id("java-conventions")
+}
+
+buildscript {
+  dependencies {
+    classpath(pluginLibs.editorconfig)
+    classpath(pluginLibs.spotless)
+  }
+}
+
+dependencies {
+  implementation(project(":spring-data-opensearch-starter"))
+  implementation(libs.jupiter)
+  implementation(springLibs.boot.docker.compose)
+  implementation(springLibs.boot.test.autoconfigure)
+  implementation(springLibs.test) {
+    exclude("ch.qos.logback", "logback-classic")
+  }
+  testImplementation("ch.qos.logback:logback-classic")  {
+    version {
+      require("1.5.6")
+    }
+    because("Compatible with spring boot")
+  }
+}
+
+description = "Spring Data OpenSearch Spring Boot Docker Compose"
+
+spotless {
+  java {
+    target("src/main/java/**/*.java", "src/test/java/org/opensearch/**/*.java")
+
+    trimTrailingWhitespace()
+    indentWithSpaces()
+    endWithNewline()
+
+    removeUnusedImports()
+    importOrder()
+  }
+}
+
+publishing {
+  publications {
+    create<MavenPublication>("publishMaven") {
+      from(components["java"])
+      pom {
+        name.set("Spring Data OpenSearch Spring Boot Docker Compose")
+        packaging = "jar"
+        artifactId = "spring-data-opensearch-docker-compose"
+        description.set("Spring Boot autoconfigurations for Spring Data Implementation for OpenSearch to support testing")
+        url.set("https://github.com/opensearch-project/spring-data-opensearch/")
+        scm {
+          connection.set("scm:git@github.com:opensearch-project/spring-data-opensearch.git")
+          developerConnection.set("scm:git@github.com:opensearch-project/spring-data-opensearch.git")
+          url.set("git@github.com:opensearch-project/spring-data-opensearch.git")
+        }
+        licenses {
+          license {
+            name.set("The Apache License, Version 2.0")
+            url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+          }
+        }
+        developers {
+          developer {
+            name.set("opensearch-project")
+            url.set("https://www.opensearch.org")
+            inceptionYear.set("2022")
+          }
+        }
+      }
+    }
+  }
+}
+
+tasks.withType<Javadoc>() {
+  options.memberLevel = JavadocMemberLevel.PACKAGE
+}

--- a/spring-data-opensearch-docker-compose/src/main/java/org/opensearch/spring/boot/docker/compose/service/connection/OpenSearchDockerComposeConnectionDetailsFactory.java
+++ b/spring-data-opensearch-docker-compose/src/main/java/org/opensearch/spring/boot/docker/compose/service/connection/OpenSearchDockerComposeConnectionDetailsFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright OpenSearch Contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.spring.boot.docker.compose.service.connection;
+
+import java.util.List;
+import org.opensearch.spring.boot.autoconfigure.OpenSearchConnectionDetails;
+import org.springframework.boot.docker.compose.core.RunningService;
+import org.springframework.boot.docker.compose.service.connection.DockerComposeConnectionDetailsFactory;
+import org.springframework.boot.docker.compose.service.connection.DockerComposeConnectionSource;
+
+class OpenSearchDockerComposeConnectionDetailsFactory
+        extends DockerComposeConnectionDetailsFactory<OpenSearchConnectionDetails> {
+
+    protected OpenSearchDockerComposeConnectionDetailsFactory() {
+        super("opensearchproject/opensearch");
+    }
+
+    @Override
+    protected OpenSearchConnectionDetails getDockerComposeConnectionDetails(DockerComposeConnectionSource source) {
+        return new OpenSearchDockerComposeConnectionDetails(source.getRunningService());
+    }
+
+    static class OpenSearchDockerComposeConnectionDetails extends DockerComposeConnectionDetails
+            implements OpenSearchConnectionDetails {
+
+        private final String uri;
+
+        private final OpenSearchEnvironment environment;
+
+        protected OpenSearchDockerComposeConnectionDetails(RunningService runningService) {
+            super(runningService);
+            this.environment = new OpenSearchEnvironment(runningService.env());
+            String protocol = this.environment.isSecurityEnabled() ? "https" : "http";
+            this.uri = "%s://%s:%d".formatted(protocol, runningService.host(), runningService.ports().get(9200));
+        }
+
+        @Override
+        public List<String> getUris() {
+            return List.of(this.uri);
+        }
+
+        @Override
+        public String getUsername() {
+            return this.environment.isSecurityEnabled() ? this.environment.getUsername() : null;
+        }
+
+        @Override
+        public String getPassword() {
+            return this.environment.isSecurityEnabled() ? this.environment.getPassword() : null;
+        }
+    }
+}

--- a/spring-data-opensearch-docker-compose/src/main/java/org/opensearch/spring/boot/docker/compose/service/connection/OpenSearchEnvironment.java
+++ b/spring-data-opensearch-docker-compose/src/main/java/org/opensearch/spring/boot/docker/compose/service/connection/OpenSearchEnvironment.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright OpenSearch Contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.spring.boot.docker.compose.service.connection;
+
+import java.util.Map;
+
+class OpenSearchEnvironment {
+
+    private final String username = "admin";
+
+    private final boolean securityEnabled;
+
+    private final String password;
+
+    OpenSearchEnvironment(Map<String, String> env) {
+        this.securityEnabled = !Boolean.parseBoolean(env.get("DISABLE_SECURITY_PLUGIN"));
+        this.password = env.getOrDefault("OPENSEARCH_INITIAL_ADMIN_PASSWORD", "admin");
+    }
+
+    public String getUsername() {
+        return this.username;
+    }
+
+    public boolean isSecurityEnabled() {
+        return this.securityEnabled;
+    }
+
+    public String getPassword() {
+        return this.password;
+    }
+}

--- a/spring-data-opensearch-docker-compose/src/main/resources/META-INF/spring.factories
+++ b/spring-data-opensearch-docker-compose/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.service.connection.ConnectionDetailsFactory=\
+org.opensearch.spring.boot.docker.compose.service.connection.OpenSearchDockerComposeConnectionDetailsFactory

--- a/spring-data-opensearch-docker-compose/src/test/java/org/opensearch/spring/boot/docker/compose/service/connection/OpenSearchDockerComposeConnectionDetailsFactoryTest.java
+++ b/spring-data-opensearch-docker-compose/src/test/java/org/opensearch/spring/boot/docker/compose/service/connection/OpenSearchDockerComposeConnectionDetailsFactoryTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright OpenSearch Contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.spring.boot.docker.compose.service.connection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import org.junit.jupiter.api.Test;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.client.RestClient;
+import org.opensearch.spring.boot.autoconfigure.OpenSearchRestClientAutoConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Configuration;
+
+@SpringBootTest(properties = {
+        "spring.docker.compose.skip.in-tests=false",
+        "spring.docker.compose.file=classpath:org/opensearch/spring/boot/docker/compose/service/connection/opensearch-compose.yaml",
+        "spring.docker.compose.stop.command=down"
+})
+class OpenSearchDockerComposeConnectionDetailsFactoryTest {
+
+    @Autowired
+    private RestClient restClient;
+
+    @Test
+    void restClientOpensearchNodeVersion() throws IOException {
+        final Request request = new Request("GET", "/");
+        final Response response = this.restClient.performRequest(request);
+        try (InputStream input = response.getEntity().getContent()) {
+            JsonNode result = new ObjectMapper().readTree(input);
+            assertThat(result.path("version").path("number").asText())
+                    .isEqualTo("2.15.0");
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @ImportAutoConfiguration(OpenSearchRestClientAutoConfiguration.class)
+    static class TestConfiguration {
+
+    }
+
+}

--- a/spring-data-opensearch-docker-compose/src/test/java/org/opensearch/spring/boot/docker/compose/service/connection/SecureOpenSearchDockerComposeConnectionDetailsFactoryTest.java
+++ b/spring-data-opensearch-docker-compose/src/test/java/org/opensearch/spring/boot/docker/compose/service/connection/SecureOpenSearchDockerComposeConnectionDetailsFactoryTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright OpenSearch Contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.spring.boot.docker.compose.service.connection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import javax.net.ssl.SSLContext;
+import org.apache.http.conn.ssl.TrustAllStrategy;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.apache.http.ssl.SSLContextBuilder;
+import org.junit.jupiter.api.Test;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.client.RestClient;
+import org.opensearch.client.RestClientBuilder;
+import org.opensearch.spring.boot.autoconfigure.OpenSearchRestClientAutoConfiguration;
+import org.opensearch.spring.boot.autoconfigure.RestClientBuilderCustomizer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@SpringBootTest(properties = {
+        "spring.docker.compose.skip.in-tests=false",
+        "spring.docker.compose.file=classpath:org/opensearch/spring/boot/docker/compose/service/connection/secure-opensearch-compose.yaml",
+        "spring.docker.compose.stop.command=down"
+})
+class SecureOpenSearchDockerComposeConnectionDetailsFactoryTest {
+
+    @Autowired
+    private RestClient restClient;
+
+    @Test
+    void restClientOpensearchNodeVersion() throws IOException {
+        final Request request = new Request("GET", "/");
+        final Response response = this.restClient.performRequest(request);
+        try (InputStream input = response.getEntity().getContent()) {
+            JsonNode result = new ObjectMapper().readTree(input);
+            assertThat(result.path("version").path("number").asText())
+                    .isEqualTo("2.15.0");
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @ImportAutoConfiguration(OpenSearchRestClientAutoConfiguration.class)
+    static class TestConfiguration {
+
+        @Bean
+        RestClientBuilderCustomizer customizer() {
+            return new RestClientBuilderCustomizer() {
+
+                @Override
+                public void customize(RestClientBuilder builder) {
+
+                }
+
+                @Override
+                public void customize(HttpAsyncClientBuilder builder) {
+                    final SSLContext sslcontext;
+                    try {
+                        sslcontext = SSLContextBuilder.create()
+                                .loadTrustMaterial(null, new TrustAllStrategy())
+                                .build();
+                    } catch (NoSuchAlgorithmException | KeyManagementException | KeyStoreException e) {
+                        throw new RuntimeException(e);
+                    }
+                    builder.setSSLContext(sslcontext);
+                }
+            };
+        }
+
+    }
+
+}

--- a/spring-data-opensearch-docker-compose/src/test/resources/org/opensearch/spring/boot/docker/compose/service/connection/opensearch-compose.yaml
+++ b/spring-data-opensearch-docker-compose/src/test/resources/org/opensearch/spring/boot/docker/compose/service/connection/opensearch-compose.yaml
@@ -1,0 +1,8 @@
+services:
+  opensearch:
+    image: opensearchproject/opensearch:2.15.0
+    ports:
+      - '9200'
+    environment:
+      - 'discovery.type=single-node'
+      - 'DISABLE_SECURITY_PLUGIN=true'

--- a/spring-data-opensearch-docker-compose/src/test/resources/org/opensearch/spring/boot/docker/compose/service/connection/secure-opensearch-compose.yaml
+++ b/spring-data-opensearch-docker-compose/src/test/resources/org/opensearch/spring/boot/docker/compose/service/connection/secure-opensearch-compose.yaml
@@ -1,0 +1,13 @@
+services:
+  opensearch:
+    image: opensearchproject/opensearch:2.15.0
+    ports:
+      - '9200'
+    healthcheck:
+      test: ["CMD-SHELL", "curl -k -u admin:D3v3l0p-ment --silent --fail https://localhost:9200/ || exit 1"]
+      interval: 10s
+      timeout: 10s
+      retries: 3
+    environment:
+      - 'discovery.type=single-node'
+      - 'OPENSEARCH_INITIAL_ADMIN_PASSWORD=D3v3l0p-ment'


### PR DESCRIPTION
Bind containers created from `opensearchproject/opensearch` when compose file is used. `OpenSearchConnectionDetails` is created from the compose file.

Signed-off-by: Eddú Meléndez <eddu.melendez@gmail.com>
