### PR TITLE
Exclude 'opensearch-rest-client-sniffer' from examples since Docker reports non-HTTPs address for container by default

### DIFF
--- a/spring-data-opensearch-examples/spring-boot-gradle/build.gradle.kts
+++ b/spring-data-opensearch-examples/spring-boot-gradle/build.gradle.kts
@@ -18,8 +18,12 @@ buildscript {
 }
 
 dependencies {
-  api(project(":spring-data-opensearch"))
-  api(project(":spring-data-opensearch-starter"))
+  api(project(":spring-data-opensearch")) {
+    exclude("org.opensearch.client", "opensearch-rest-client-sniffer")
+  }
+  api(project(":spring-data-opensearch-starter")) {
+    exclude("org.opensearch.client", "opensearch-rest-client-sniffer")
+  }
   implementation(springLibs.boot.web)
   implementation(jacksonLibs.core)
   implementation(jacksonLibs.databind)

--- a/spring-data-opensearch-examples/spring-boot-java-client-gradle/build.gradle.kts
+++ b/spring-data-opensearch-examples/spring-boot-java-client-gradle/build.gradle.kts
@@ -20,9 +20,11 @@ buildscript {
 dependencies {
   api(project(":spring-data-opensearch")) {
     exclude("org.opensearch.client", "opensearch-rest-high-level-client")
+    exclude("org.opensearch.client", "opensearch-rest-client-sniffer")
   }
   api(project(":spring-data-opensearch-starter")) {
     exclude("org.opensearch.client", "opensearch-rest-high-level-client")
+    exclude("org.opensearch.client", "opensearch-rest-client-sniffer")
   }
   implementation(springLibs.boot.web)
   implementation(jacksonLibs.core)


### PR DESCRIPTION
### Description
Exclude 'opensearch-rest-client-sniffer' from examples since Docker reports non-HTTPs address for container by default

### Issues Resolved
See please https://forum.opensearch.org/t/spring-data-opensearch-example-not-working/17033/3

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
