### PR TITLE
Exclude ``opensearch-rest-client-sniffer`` from spring-data-opensearch-starter

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -36,8 +36,7 @@ dependencyResolutionManagement {
       library("java-client", "org.opensearch.client:opensearch-java:2.13.0")
       library("client", "org.opensearch.client", "opensearch-rest-client").versionRef("opensearch")
       library("high-level-client", "org.opensearch.client", "opensearch-rest-high-level-client").versionRef("opensearch")
-      library("sniffer", "org.opensearch.client", "opensearch-rest-client-sniffer").versionRef("opensearch")
-      library("testcontainers", "org.opensearch:opensearch-testcontainers:2.1.0") 
+      library("testcontainers", "org.opensearch:opensearch-testcontainers:2.1.0")
     }
     
     create("jacksonLibs") {

--- a/spring-data-opensearch-examples/spring-boot-gradle/build.gradle.kts
+++ b/spring-data-opensearch-examples/spring-boot-gradle/build.gradle.kts
@@ -18,12 +18,8 @@ buildscript {
 }
 
 dependencies {
-  api(project(":spring-data-opensearch")) {
-    exclude("org.opensearch.client", "opensearch-rest-client-sniffer")
-  }
-  api(project(":spring-data-opensearch-starter")) {
-    exclude("org.opensearch.client", "opensearch-rest-client-sniffer")
-  }
+  api(project(":spring-data-opensearch"))
+  api(project(":spring-data-opensearch-starter"))
   implementation(springLibs.boot.web)
   implementation(jacksonLibs.core)
   implementation(jacksonLibs.databind)

--- a/spring-data-opensearch-examples/spring-boot-java-client-gradle/build.gradle.kts
+++ b/spring-data-opensearch-examples/spring-boot-java-client-gradle/build.gradle.kts
@@ -20,11 +20,9 @@ buildscript {
 dependencies {
   api(project(":spring-data-opensearch")) {
     exclude("org.opensearch.client", "opensearch-rest-high-level-client")
-    exclude("org.opensearch.client", "opensearch-rest-client-sniffer")
   }
   api(project(":spring-data-opensearch-starter")) {
     exclude("org.opensearch.client", "opensearch-rest-high-level-client")
-    exclude("org.opensearch.client", "opensearch-rest-client-sniffer")
   }
   implementation(springLibs.boot.web)
   implementation(jacksonLibs.core)

--- a/spring-data-opensearch-starter/build.gradle.kts
+++ b/spring-data-opensearch-starter/build.gradle.kts
@@ -23,9 +23,6 @@ dependencies {
     exclude("commons-logging", "commons-logging")
     exclude("org.slf4j", "slf4j-api")
   }
-  implementation(opensearchLibs.sniffer) {
-    exclude("commons-logging", "commons-logging")
-  }
   compileOnly(opensearchLibs.java.client)
   compileOnly(jakarta.json.bind)
   testImplementation(springLibs.test) {

--- a/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/OpenSearchRestClientAutoConfiguration.java
+++ b/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/OpenSearchRestClientAutoConfiguration.java
@@ -9,7 +9,6 @@ import java.util.List;
 import org.opensearch.client.RestClientBuilder;
 import org.opensearch.spring.boot.autoconfigure.OpenSearchRestClientConfigurations.RestClientBuilderConfiguration;
 import org.opensearch.spring.boot.autoconfigure.OpenSearchRestClientConfigurations.RestClientConfiguration;
-import org.opensearch.spring.boot.autoconfigure.OpenSearchRestClientConfigurations.RestClientSnifferConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -27,7 +26,7 @@ import org.springframework.context.annotation.Import;
 @AutoConfiguration
 @ConditionalOnClass(RestClientBuilder.class)
 @EnableConfigurationProperties(OpenSearchProperties.class)
-@Import({RestClientBuilderConfiguration.class, RestClientConfiguration.class, RestClientSnifferConfiguration.class})
+@Import({RestClientBuilderConfiguration.class, RestClientConfiguration.class})
 public class OpenSearchRestClientAutoConfiguration {
 
     @Bean

--- a/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/OpenSearchRestClientConfigurations.java
+++ b/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/OpenSearchRestClientConfigurations.java
@@ -8,6 +8,7 @@ package org.opensearch.spring.boot.autoconfigure;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
+
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.Credentials;
@@ -18,12 +19,8 @@ import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
 import org.apache.http.impl.nio.reactor.IOReactorConfig;
 import org.opensearch.client.RestClient;
 import org.opensearch.client.RestClientBuilder;
-import org.opensearch.client.sniff.Sniffer;
-import org.opensearch.client.sniff.SnifferBuilder;
 import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate;
 import org.springframework.boot.context.properties.PropertyMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -107,24 +104,6 @@ class OpenSearchRestClientConfigurations {
         @Bean
         RestClient opensearchRestClient(RestClientBuilder restClientBuilder) {
             return restClientBuilder.build();
-        }
-    }
-
-    @Configuration(proxyBeanMethods = false)
-    @ConditionalOnClass(Sniffer.class)
-    @ConditionalOnSingleCandidate(RestClient.class)
-    static class RestClientSnifferConfiguration {
-
-        @Bean
-        @ConditionalOnMissingBean
-        Sniffer opensearchSniffer(RestClient client, OpenSearchProperties properties) {
-            SnifferBuilder builder = Sniffer.builder(client);
-            PropertyMapper map = PropertyMapper.get().alwaysApplyingWhenNonNull();
-            Duration interval = properties.getRestclient().getSniffer().getInterval();
-            map.from(interval).asInt(Duration::toMillis).to(builder::setSniffIntervalMillis);
-            Duration delayAfterFailure = properties.getRestclient().getSniffer().getDelayAfterFailure();
-            map.from(delayAfterFailure).asInt(Duration::toMillis).to(builder::setSniffAfterFailureDelayMillis);
-            return builder.build();
         }
     }
 


### PR DESCRIPTION
### Description
Exclude ``opensearch-rest-client-sniffer`` from spring-data-opensearch-starter.

### Issues Resolved
resolve #323 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
