### PR TITLE
Change dependency configuration of ``opensearch-rest-client-sniffer``

### DIFF
--- a/spring-data-opensearch-examples/spring-boot-gradle/build.gradle.kts
+++ b/spring-data-opensearch-examples/spring-boot-gradle/build.gradle.kts
@@ -18,12 +18,8 @@ buildscript {
 }
 
 dependencies {
-  api(project(":spring-data-opensearch")) {
-    exclude("org.opensearch.client", "opensearch-rest-client-sniffer")
-  }
-  api(project(":spring-data-opensearch-starter")) {
-    exclude("org.opensearch.client", "opensearch-rest-client-sniffer")
-  }
+  api(project(":spring-data-opensearch"))
+  api(project(":spring-data-opensearch-starter"))
   implementation(springLibs.boot.web)
   implementation(jacksonLibs.core)
   implementation(jacksonLibs.databind)

--- a/spring-data-opensearch-examples/spring-boot-java-client-gradle/build.gradle.kts
+++ b/spring-data-opensearch-examples/spring-boot-java-client-gradle/build.gradle.kts
@@ -20,11 +20,9 @@ buildscript {
 dependencies {
   api(project(":spring-data-opensearch")) {
     exclude("org.opensearch.client", "opensearch-rest-high-level-client")
-    exclude("org.opensearch.client", "opensearch-rest-client-sniffer")
   }
   api(project(":spring-data-opensearch-starter")) {
     exclude("org.opensearch.client", "opensearch-rest-high-level-client")
-    exclude("org.opensearch.client", "opensearch-rest-client-sniffer")
   }
   implementation(springLibs.boot.web)
   implementation(jacksonLibs.core)

--- a/spring-data-opensearch-starter/build.gradle.kts
+++ b/spring-data-opensearch-starter/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
     exclude("commons-logging", "commons-logging")
     exclude("org.slf4j", "slf4j-api")
   }
-  implementation(opensearchLibs.sniffer) {
+  compileOnly(opensearchLibs.sniffer) {
     exclude("commons-logging", "commons-logging")
   }
   compileOnly(opensearchLibs.java.client)
@@ -35,6 +35,9 @@ dependencies {
   testImplementation(opensearchLibs.testcontainers)
   testImplementation(jacksonLibs.core)
   testImplementation(jacksonLibs.databind)
+  testImplementation(opensearchLibs.sniffer) {
+    exclude("commons-logging", "commons-logging")
+  }
 }
 
 description = "Spring Data OpenSearch Spring Boot Starter"


### PR DESCRIPTION
### Description
Change dependency configuration of  ``opensearch-rest-client-sniffer`` from implementation to compileOnly

### Issues Resolved
resolve #323 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
