### PR TITLE
Set refresh on DeleteByQueryRequest by DeleteQuery

### DIFF
--- a/spring-data-opensearch/src/main/java/org/opensearch/data/client/orhlc/RequestFactory.java
+++ b/spring-data-opensearch/src/main/java/org/opensearch/data/client/orhlc/RequestFactory.java
@@ -596,7 +596,7 @@ class RequestFactory {
         DeleteByQueryRequest deleteByQueryRequest = new DeleteByQueryRequest(index.getIndexNames()) //
                 .setQuery(searchRequest.source().query()) //
                 .setAbortOnVersionConflict(false) //
-                .setRefresh(deleteByQueryRefresh(refreshPolicy))
+                .setRefresh(query.getRefresh() != null ? query.getRefresh() : deleteByQueryRefresh(refreshPolicy))
                 .setIndicesOptions(
                     new org.opensearch.action.support.IndicesOptions(
                         options.isEmpty()

--- a/spring-data-opensearch/src/main/java/org/opensearch/data/client/osc/RequestConverter.java
+++ b/spring-data-opensearch/src/main/java/org/opensearch/data/client/osc/RequestConverter.java
@@ -1018,6 +1018,9 @@ class RequestConverter {
                                     .collect(Collectors.toList()));
                 }
             }
+            if (query.getRefresh() != null) {
+                dqb.refresh(query.getRefresh());
+            }
             dqb.allowNoIndices(query.getAllowNoIndices())
                     .conflicts(conflicts(query.getConflicts()))
                     .ignoreUnavailable(query.getIgnoreUnavailable())

--- a/spring-data-opensearch/src/test/java/org/opensearch/data/client/orhlc/RequestFactoryTests.java
+++ b/spring-data-opensearch/src/test/java/org/opensearch/data/client/orhlc/RequestFactoryTests.java
@@ -1106,6 +1106,19 @@ class RequestFactoryTests {
         assertThat(deleteByQueryRequest.isRefresh()).isFalse();
     }
 
+    @Test // #335
+    @DisplayName("should set refresh based on deleteRequest")
+    void refreshSetByDeleteRequest() {
+        var methodIndexName = "method-index-name";
+        var query = new CriteriaQuery(new Criteria("lastName").contains("test"));
+        var deleteQuery = DeleteQuery.builder(query).withRefresh(true).build();
+
+        var deleteByQueryRequest = requestFactory.documentDeleteByQueryRequest(deleteQuery, null, Person.class,
+            IndexCoordinates.of(methodIndexName), null);
+
+        assertThat(deleteByQueryRequest.isRefresh()).isTrue();
+    }
+
     // region entities
     static class Person {
         @Nullable

--- a/spring-data-opensearch/src/test/java/org/opensearch/data/client/osc/RequestConverterTest.java
+++ b/spring-data-opensearch/src/test/java/org/opensearch/data/client/osc/RequestConverterTest.java
@@ -28,6 +28,9 @@ import org.springframework.data.elasticsearch.annotations.FieldType;
 import org.springframework.data.elasticsearch.core.convert.MappingElasticsearchConverter;
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.data.elasticsearch.core.mapping.SimpleElasticsearchMappingContext;
+import org.springframework.data.elasticsearch.core.query.Criteria;
+import org.springframework.data.elasticsearch.core.query.CriteriaQuery;
+import org.springframework.data.elasticsearch.core.query.DeleteQuery;
 import org.springframework.data.elasticsearch.core.query.DocValueField;
 import org.springframework.data.elasticsearch.core.query.StringQuery;
 import org.springframework.lang.Nullable;
@@ -67,6 +70,19 @@ class RequestConverterTest {
         assertThat(fieldAndFormats.get(0).format()).isNull();
         assertThat(fieldAndFormats.get(1).field()).isEqualTo("field2");
         assertThat(fieldAndFormats.get(1).format()).isEqualTo("format2");
+    }
+
+    @Test // #335
+    @DisplayName("should set refresh based on deleteRequest")
+    void refreshSetByDeleteRequest() {
+        var query = new CriteriaQuery(new Criteria("text").contains("test"));
+        var deleteQuery = DeleteQuery.builder(query).withRefresh(true).build();
+
+        var deleteByQueryRequest = requestConverter.documentDeleteByQueryRequest(deleteQuery, null, SampleEntity.class,
+            IndexCoordinates.of("foo"),
+            null);
+
+        assertThat(deleteByQueryRequest.refresh()).isTrue();
     }
 
     @Document(indexName = "does-not-matter")


### PR DESCRIPTION
### Description
Set refresh on DeleteByQueryRequest by DeleteQuery

### Issues Resolved
resolve #335 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
