### PR TITLE
Update the snapshot workflow name

### DIFF
--- a/.github/workflows/publish-snapshots.yml
+++ b/.github/workflows/publish-snapshots.yml
@@ -1,4 +1,4 @@
-name: Publish snapshots to Apache Maven repositories
+name: Publish snapshots to maven
 
 on:
   push:


### PR DESCRIPTION
### Description
Update the snapshot workflow name to keep it consistent with other repos. This is to ensure the that the critical workflows like `Publish snapshots to maven` are monitored.  Part of https://github.com/opensearch-project/opensearch-build/issues/4941. The monitoring framework monitors the workflows based on the workflow names.

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-build/issues/4941

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
