### PR TITLE
Update Wiremock to 3.10.0

### DIFF
--- a/spring-data-opensearch/build.gradle.kts
+++ b/spring-data-opensearch/build.gradle.kts
@@ -58,7 +58,7 @@ dependencies {
   testImplementation(springLibs.test) {
     exclude("ch.qos.logback", "logback-classic")
   }
-  testImplementation("org.wiremock:wiremock:3.9.2") {
+  testImplementation("org.wiremock:wiremock:3.10.0") {
     exclude("commons-logging", "commons-logging")
     exclude("org.ow2.asm", "asm")
   }


### PR DESCRIPTION
### Description
Update Wiremock to 3.10.0

### Issues Resolved
Closes https://github.com/opensearch-project/spring-data-opensearch/issues/362

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
