### PR TITLE
Inconsistency between java client and OpenSearch update by query responses

### DIFF
--- a/spring-data-opensearch/src/main/java/org/opensearch/data/client/osc/ResponseConverter.java
+++ b/spring-data-opensearch/src/main/java/org/opensearch/data/client/osc/ResponseConverter.java
@@ -489,6 +489,10 @@ class ResponseConverter {
             builder.withDeleted(response.deleted());
         }
 
+        if (response.updated() != null) {
+            builder.withUpdated(response.updated());
+        }
+
         if (response.batches() != null) {
             builder.withBatches(Math.toIntExact(response.batches()));
         }


### PR DESCRIPTION
### Description
Inconsistency between java client and OpenSearch update by query responses

### Issues Resolved
Closes https://github.com/opensearch-project/spring-data-opensearch/issues/387

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
