### PR TITLE
 Update Spring Boot to 3.4.3 and OpenSearch to 2.19.0 

### DIFF
--- a/buildSrc/src/main/kotlin/java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-conventions.gradle.kts
@@ -67,8 +67,8 @@ versionCatalogs
   }
 
 dependencies {
-  testImplementation("org.testcontainers:testcontainers:1.20.4")
-  testImplementation("org.testcontainers:junit-jupiter:1.20.4")
+  testImplementation("org.testcontainers:testcontainers:1.20.5")
+  testImplementation("org.testcontainers:junit-jupiter:1.20.5")
   testImplementation("org.mockito:mockito-junit-jupiter:5.15.2")
   testImplementation("org.assertj:assertj-core:3.27.3")
   testImplementation("ch.qos.logback:logback-classic:1.5.16")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,7 +15,7 @@ dependencyResolutionManagement {
 
     create("springLibs") {
       version("spring", "6.2.2")
-      version("spring-boot", "3.4.2")
+      version("spring-boot", "3.4.3")
       library("data-commons", "org.springframework.data:spring-data-commons:3.4.3")
       library("data-elasticsearch", "org.springframework.data:spring-data-elasticsearch:5.4.3")
       library("web", "org.springframework", "spring-web").versionRef("spring")
@@ -32,7 +32,7 @@ dependencyResolutionManagement {
     }
     
     create("opensearchLibs") {
-      version("opensearch", "2.18.0")
+      version("opensearch", "2.19.0")
       library("java-client", "org.opensearch.client:opensearch-java:2.21.0")
       library("client", "org.opensearch.client", "opensearch-rest-client").versionRef("opensearch")
       library("high-level-client", "org.opensearch.client", "opensearch-rest-high-level-client").versionRef("opensearch")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,7 +14,7 @@ dependencyResolutionManagement {
     }
 
     create("springLibs") {
-      version("spring", "6.2.2")
+      version("spring", "6.2.3")
       version("spring-boot", "3.4.3")
       library("data-commons", "org.springframework.data:spring-data-commons:3.4.3")
       library("data-elasticsearch", "org.springframework.data:spring-data-elasticsearch:5.4.3")


### PR DESCRIPTION
### Description
 Update Spring Boot to 3.4.3 and OpenSearch to 2.19.0 

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
