### PR TITLE
use `ServiceConnection` in examples' tests

### DIFF
--- a/spring-data-opensearch-examples/spring-boot-gradle/src/test/java/org/opensearch/data/example/repository/MarketplaceRepositoryIntegrationTests.java
+++ b/spring-data-opensearch-examples/spring-boot-gradle/src/test/java/org/opensearch/data/example/repository/MarketplaceRepositoryIntegrationTests.java
@@ -13,34 +13,24 @@ import org.junit.jupiter.api.Test;
 import org.opensearch.spring.boot.autoconfigure.test.DataOpenSearchTest;
 import org.opensearch.testcontainers.OpensearchContainer;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.util.TestPropertyValues;
-import org.springframework.context.ApplicationContextInitializer;
-import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
-import org.springframework.test.context.ContextConfiguration;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers(disabledWithoutDocker = true)
 @DataOpenSearchTest
 @EnableElasticsearchRepositories(basePackageClasses = MarketplaceRepository.class)
-@ContextConfiguration(initializers = MarketplaceRepositoryIntegrationTests.Initializer.class)
 @Tag("integration-test")
 public class MarketplaceRepositoryIntegrationTests {
     @Container
+    @ServiceConnection
     static final OpensearchContainer<?> opensearch = new OpensearchContainer<>("opensearchproject/opensearch:2.19.1")
             .withStartupAttempts(5)
             .withStartupTimeout(Duration.ofMinutes(2));
 
     @Test
     void testMarketplaceRepository(@Autowired MarketplaceRepository repository) {
-        assertThat(repository.findAll()).hasSize(0);
-    }
-
-    static class Initializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
-        public void initialize(ConfigurableApplicationContext configurableApplicationContext) {
-            TestPropertyValues.of("opensearch.uris=" + opensearch.getHttpHostAddress())
-                    .applyTo(configurableApplicationContext.getEnvironment());
-        }
+        assertThat(repository.findAll()).isEmpty();
     }
 }

--- a/spring-data-opensearch-examples/spring-boot-java-client-gradle/src/test/java/org/opensearch/data/example/repository/MarketplaceRepositoryIntegrationTests.java
+++ b/spring-data-opensearch-examples/spring-boot-java-client-gradle/src/test/java/org/opensearch/data/example/repository/MarketplaceRepositoryIntegrationTests.java
@@ -13,34 +13,24 @@ import org.junit.jupiter.api.Test;
 import org.opensearch.spring.boot.autoconfigure.test.DataOpenSearchTest;
 import org.opensearch.testcontainers.OpensearchContainer;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.util.TestPropertyValues;
-import org.springframework.context.ApplicationContextInitializer;
-import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
-import org.springframework.test.context.ContextConfiguration;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers(disabledWithoutDocker = true)
 @DataOpenSearchTest
 @EnableElasticsearchRepositories(basePackageClasses = MarketplaceRepository.class)
-@ContextConfiguration(initializers = MarketplaceRepositoryIntegrationTests.Initializer.class)
 @Tag("integration-test")
 public class MarketplaceRepositoryIntegrationTests {
     @Container
+    @ServiceConnection
     static final OpensearchContainer<?> opensearch = new OpensearchContainer<>("opensearchproject/opensearch:2.19.1")
             .withStartupAttempts(5)
             .withStartupTimeout(Duration.ofMinutes(2));
 
     @Test
     void testMarketplaceRepository(@Autowired MarketplaceRepository repository) {
-        assertThat(repository.findAll()).hasSize(0);
-    }
-
-    static class Initializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
-        public void initialize(ConfigurableApplicationContext configurableApplicationContext) {
-            TestPropertyValues.of("opensearch.uris=" + opensearch.getHttpHostAddress())
-                    .applyTo(configurableApplicationContext.getEnvironment());
-        }
+        assertThat(repository.findAll()).isEmpty();
     }
 }


### PR DESCRIPTION
### Description
the tests of the examples can and should use `ServiceConnection` rather than manually setting the properties. this shows the correct way of using them with `Testcontainers`.

### Issues Resolved
n/a

### Check List
- [ ] ~~New functionality includes testing.~~
  - [x] All tests pass
- [ ] ~~New functionality has been documented.~~
  - [ ] ~~New functionality has javadoc added~~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
