### PR TITLE
Use records to make code more concise

### DIFF
--- a/spring-data-opensearch/src/main/java/org/opensearch/data/client/orhlc/ScriptField.java
+++ b/spring-data-opensearch/src/main/java/org/opensearch/data/client/orhlc/ScriptField.java
@@ -13,23 +13,9 @@ import org.opensearch.script.Script;
 
 /**
  * Scripted field
+ *
  * @since 0.1
  */
-public class ScriptField {
+public record ScriptField(String fieldName, Script script) {
 
-    private final String fieldName;
-    private final Script script;
-
-    public ScriptField(String fieldName, Script script) {
-        this.fieldName = fieldName;
-        this.script = script;
-    }
-
-    public String fieldName() {
-        return fieldName;
-    }
-
-    public Script script() {
-        return script;
-    }
 }

--- a/spring-data-opensearch/src/main/java/org/opensearch/data/client/osc/Aggregation.java
+++ b/spring-data-opensearch/src/main/java/org/opensearch/data/client/osc/Aggregation.java
@@ -18,27 +18,18 @@ package org.opensearch.data.client.osc;
 import org.opensearch.client.opensearch._types.aggregations.Aggregate;
 
 /**
- * Class to combine an OpenSearch {@link org.opensearch.client.opensearch._types.aggregations.Aggregate} with its
- * name. Necessary as the OpenSearch Aggregate does not know its name.
+ * Class to combine an OpenSearch {@link Aggregate} with its name. Necessary as the OpenSearch Aggregate does not know its name.
  *
  * @author Peter-Josef Meisch
  * @since 4.4
  */
-public class Aggregation {
-
-    private final String name;
-    private final Aggregate aggregate;
-
-    public Aggregation(String name, Aggregate aggregate) {
-        this.name = name;
-        this.aggregate = aggregate;
-    }
+public record Aggregation(String name, Aggregate aggregate) {
 
     public String getName() {
-        return name;
+        return name();
     }
 
     public Aggregate getAggregate() {
-        return aggregate;
+        return aggregate();
     }
 }

--- a/spring-data-opensearch/src/main/java/org/opensearch/data/client/osc/OpenSearchAggregation.java
+++ b/spring-data-opensearch/src/main/java/org/opensearch/data/client/osc/OpenSearchAggregation.java
@@ -18,20 +18,11 @@ package org.opensearch.data.client.osc;
 import org.springframework.data.elasticsearch.core.AggregationContainer;
 
 /**
- * {@link AggregationContainer} for a {@link Aggregation} that holds OpenEearch data.
+ * {@link AggregationContainer} for a {@link Aggregation} that holds OpenSearch data.
+ *
  * @author Peter-Josef Meisch
  * @since 4.4
  */
-public class OpenSearchAggregation implements AggregationContainer<Aggregation> {
+public record OpenSearchAggregation(Aggregation aggregation) implements AggregationContainer<Aggregation> {
 
-    private final Aggregation aggregation;
-
-    public OpenSearchAggregation(Aggregation aggregation) {
-        this.aggregation = aggregation;
-    }
-
-    @Override
-    public Aggregation aggregation() {
-        return aggregation;
-    }
 }

--- a/spring-data-opensearch/src/test/java/org/opensearch/data/client/core/aggregation/AggregationOSCIntegrationTests.java
+++ b/spring-data-opensearch/src/test/java/org/opensearch/data/client/core/aggregation/AggregationOSCIntegrationTests.java
@@ -54,7 +54,7 @@ public class AggregationOSCIntegrationTests extends AggregationIntegrationTests 
         List<OpenSearchAggregation> aggregations = ((OpenSearchAggregations) aggregationsContainer).aggregations();
         List<String> aggNames = aggregations.stream() //
                 .map(OpenSearchAggregation::aggregation) //
-                .map(org.opensearch.data.client.osc.Aggregation::getName) //
+                .map(org.opensearch.data.client.osc.Aggregation::name) //
                 .collect(Collectors.toList());
         assertThat(aggNames).contains(aggsName);
 
@@ -77,8 +77,8 @@ public class AggregationOSCIntegrationTests extends AggregationIntegrationTests 
             AggregationsContainer<?> aggregationsContainer, String aggsName, String pipelineAggsName) {
         Map<String, Aggregate> aggregates = ((OpenSearchAggregations) aggregationsContainer).aggregations().stream() //
                 .map(OpenSearchAggregation::aggregation) //
-                .collect(Collectors.toMap(org.opensearch.data.client.osc.Aggregation::getName,
-                        org.opensearch.data.client.osc.Aggregation::getAggregate));
+                .collect(Collectors.toMap(org.opensearch.data.client.osc.Aggregation::name,
+                        org.opensearch.data.client.osc.Aggregation::aggregate));
 
         assertThat(aggregates).containsKey(aggsName);
         Aggregate aggregate = aggregates.get(pipelineAggsName);


### PR DESCRIPTION
I believe this is a compatible change. Also since source compatibility is set to Java 17 I think records are guaranteed to be available in all compatible runtimes.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
