### PR TITLE
Update Spring Framework to 6.2.7 and Spring Data Elasticsearch to 5.4.6

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,10 +16,10 @@ dependencyResolutionManagement {
     }
 
     create("springLibs") {
-      version("spring", "6.2.6")
-      version("spring-boot", "3.4.4")
-      library("data-commons", "org.springframework.data:spring-data-commons:3.4.5")
-      library("data-elasticsearch", "org.springframework.data:spring-data-elasticsearch:5.4.5")
+      version("spring", "6.2.7")
+      version("spring-boot", "3.4.5")
+      library("data-commons", "org.springframework.data:spring-data-commons:3.4.6")
+      library("data-elasticsearch", "org.springframework.data:spring-data-elasticsearch:5.4.6")
       library("web", "org.springframework", "spring-web").versionRef("spring")
       library("context", "org.springframework", "spring-context").versionRef("spring")
       library("tx", "org.springframework", "spring-tx").versionRef("spring")


### PR DESCRIPTION
### Description
Update Spring Framework to 6.2.7

### Issues Resolved
[CVE-2025-22233](https://spring.io/blog/2025/05/15/spring-framework-6-1-20-and-6-2-7-releases-fix-cve-2025-22233)

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
