### PR TITLE
Update the maven snapshot publish endpoint and credential

### DIFF
--- a/.github/workflows/publish-snapshots.yml
+++ b/.github/workflows/publish-snapshots.yml
@@ -18,15 +18,15 @@ jobs:
         with:
           java-version: 17
           distribution: 'temurin'
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+      - name: Load secret
+        uses: 1password/load-secrets-action@v2
         with:
-          role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}
-          aws-region: us-east-1
+          # Export loaded secrets as environment variables
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          SONATYPE_USERNAME: op://opensearch-infra-secrets/maven-central-portal-credentials/username
+          SONATYPE_PASSWORD: op://opensearch-infra-secrets/maven-central-portal-credentials/password
       - name: publish snapshots to Apache Maven repositories
         run: |
-          export SONATYPE_USERNAME=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-username --query SecretString --output text)
-          export SONATYPE_PASSWORD=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-password --query SecretString --output text)
-          echo "::add-mask::$SONATYPE_USERNAME"
-          echo "::add-mask::$SONATYPE_PASSWORD"
           ./gradlew --no-daemon publishPublishMavenPublicationToSnapshotsRepository

--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ If you'd rather like the latest snapshots of the upcoming major version, use our
 <repository>
   <id>opensearch-libs-snapshot</id>
   <name>AWS Snapshot Repository</name>
-  <url>https://aws.oss.sonatype.org/content/repositories/snapshots/</url>
+  <url>https://central.sonatype.com/repository/maven-snapshots/</url>
 </repository>
 ```
 
@@ -387,7 +387,7 @@ dependencies {
 repositories {
   ...
   maven {
-    url = "https://aws.oss.sonatype.org/content/repositories/snapshots/"
+    url = "https://central.sonatype.com/repository/maven-snapshots/"
   }
   ...
 }

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -41,4 +41,4 @@ The release process is standard across repositories in this org and is run by a 
 1. Increment "version" in [version.properties](./version.properties) to the next iteration, e.g. v2.1.1. See [example](https://github.com/opensearch-project/spring-data-opensearch/pull/75).
 
 ## Snapshot Builds
-The [snapshots builds](https://aws.oss.sonatype.org/content/repositories/snapshots/org/opensearch/client/spring-data-opensearch/) are published to sonatype using [publish-snapshots.yml](./.github/workflows/publish-snapshots.yml) workflow. Each `push` event to the main branch triggers this workflow.
+The [snapshots builds](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/org/opensearch/client/spring-data-opensearch/) are published to sonatype using [publish-snapshots.yml](./.github/workflows/publish-snapshots.yml) workflow. Each `push` event to the main branch triggers this workflow.

--- a/buildSrc/src/main/kotlin/java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-conventions.gradle.kts
@@ -109,7 +109,7 @@ tasks.test {
 publishing {
   repositories {
     if (version.toString().endsWith("SNAPSHOT")) {
-      maven("https://aws.oss.sonatype.org/content/repositories/snapshots/") {
+      maven("https://central.sonatype.com/repository/maven-snapshots/") {
         name = "Snapshots"
         credentials {
             username = System.getenv("SONATYPE_USERNAME")


### PR DESCRIPTION
### Description
Update the Maven Snapshots publish URL in accordance with the recent Sonatype migration. 
https://central.sonatype.org/publish/publish-portal-snapshots/

We have stored the `onepassword` token in this repo secrets and new credentials for Sonatypes username & password have been stored in `onepassword`.  These credentials will be exported as env variables which used by maven publish.

### Related Issues
Part of a campaign issue https://github.com/opensearch-project/opensearch-build/issues/5551

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
