### PR TITLE
Extract index name properly when translating not found exception.

### DIFF
--- a/spring-data-opensearch/src/main/java/org/opensearch/data/client/orhlc/OpenSearchExceptionTranslator.java
+++ b/spring-data-opensearch/src/main/java/org/opensearch/data/client/orhlc/OpenSearchExceptionTranslator.java
@@ -64,7 +64,7 @@ public class OpenSearchExceptionTranslator implements PersistenceExceptionTransl
 
             if (statusException.status() == RestStatus.NOT_FOUND) {
                 if (statusException.getMessage().contains("index_not_found_exception")) {
-                    Pattern pattern = Pattern.compile("no such index \\[([^\\[\\]]+)]");
+                    Pattern pattern = Pattern.compile("no such index \\[([^\\]]+)]");
                     String index = "";
                     Matcher matcher = pattern.matcher(statusException.getMessage());
                     if (matcher.find()) {

--- a/spring-data-opensearch/src/main/java/org/opensearch/data/client/orhlc/OpenSearchExceptionTranslator.java
+++ b/spring-data-opensearch/src/main/java/org/opensearch/data/client/orhlc/OpenSearchExceptionTranslator.java
@@ -64,10 +64,10 @@ public class OpenSearchExceptionTranslator implements PersistenceExceptionTransl
 
             if (statusException.status() == RestStatus.NOT_FOUND) {
                 if (statusException.getMessage().contains("index_not_found_exception")) {
-                    Pattern pattern = Pattern.compile(".*no such index \\[(.*)\\]");
+                    Pattern pattern = Pattern.compile("no such index \\[([^\\[\\]]+)]");
                     String index = "";
                     Matcher matcher = pattern.matcher(statusException.getMessage());
-                    if (matcher.matches()) {
+                    if (matcher.find()) {
                         index = matcher.group(1);
                     }
 


### PR DESCRIPTION
### Description
This PR fixes incorrectly matched index name when translating index not found exception.

### Issues Resolved
N/A

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
