### PR TITLE
Fix auto-publishing to maven central

### DIFF
--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -1,4 +1,4 @@
-lib = library(identifier: 'jenkins@10.0.0', retriever: modernSCM([
+lib = library(identifier: 'jenkins@10.0.1', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))


### PR DESCRIPTION
### Description
This change accommodates new version of build-library that fixes the auto-publish parameter in the script. Related [change](https://github.com/opensearch-project/opensearch-build-libraries/pull/720/files).

### Issues Resolved
https://github.com/opensearch-project/opensearch-java/pull/1658#issuecomment-3054341204

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
