### PR TITLE
docs: add JDK compatibility matrix to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The Spring Data OpenSearch follows the release model of the Spring Data Elastics
 
 ### OpenSearch 3.x / 2.x client libraries
 
-| Spring Data Release Train | Spring Data OpenSearch | Spring Data Elasticsearch | OpenSearch Server | OpenSearch Client   | Spring Framework | Spring Boot     | ClientJDK Version     |
+| Spring Data Release Train | Spring Data OpenSearch | Spring Data Elasticsearch | OpenSearch Server | OpenSearch Client   | Spring Framework | Spring Boot     | JDK    |
 |---------------------------|------------------------|----------------------------|-------------------|---------------------|------------------|----------------|-----------------------|
 | 2025.0                    | 2.0.x                  | 5.5.x                      | 2.x / 3.x         | 3.0.x and above     | 6.2.x            | 3.5.x          | 21+                   |
 | 2025.0                    | 1.8.x                  | 5.5.x                      | 1.x / 2.x / 3.x   | 2.10.x and above    | 6.2.x            | 3.5.x          | 17+                   |

--- a/README.md
+++ b/README.md
@@ -22,23 +22,22 @@ The Spring Data OpenSearch follows the release model of the Spring Data Elastics
 
 ### Compatibility Matrix
 
-| Spring Data Release Train | Spring Data OpenSearch | Spring Data Elasticsearch | OpenSearch Server | OpenSearch Client | Spring Framework | Spring Boot   |
-|---------------------------|------------------------|---------------------------|-------------------|-------------------|------------------|---------------|
-| 2025.0                    | 2.0.x                  | 5.5.x                     | 2.x / 3.x         | 3.0.x and above   | 6.2.x            | 3.5.x         |
-| 2025.0                    | 1.8.x                  | 5.5.x                     | 1.x / 2.x / 3.x   | 2.10.x and above  | 6.2.x            | 3.5.x         |
-| 2025.0                    | 1.7.x                  | 5.5.x                     | 1.x / 2.x / 3.x   | 2.10.x and above  | 6.2.x            | 3.5.x         |
-| 2024.1                    | 1.6.x                  | 5.4.x                     | 1.x / 2.x         | 2.10.x and above  | 6.2.x            | 3.4.x         |
-| 2024.0                    | 1.5.x                  | 5.3.x                     | 1.x / 2.x         | 2.10.x and above  | 6.1.x            | 3.2.x / 3.3.x |
-| 2023.1 (Vaughan)          | 1.4.x                  | 5.2.x                     | 1.x / 2.x         | 2.10.x and above  | 6.1.x            | 3.2.x         |
-| 2023.1 (Vaughan)          | 1.3.x                  | 5.2.x                     | 1.x / 2.x         | 2.7.x and above   | 6.1.x            | 3.2.x         |
-| 2023.0 (Ullman)           | 1.2.x                  | 5.1.x                     | 1.x / 2.x         | 2.7.x and above   | 6.0.x            | 3.1.x         |
-| 2022.0 (Turing)           | 1.1.x                  | 5.0.x                     | 1.x / 2.x         | 2.7.x and above   | 6.0.x            | 3.0.x         |
-| 2022.0 (Turing)           | 1.0.x                  | 5.0.x                     | 1.x / 2.x         | 1.x / 2.6.x       | 6.0.x            | 3.0.x         |
-| 2022.0 (Turing)           | 0.2.0                  | 5.0.x                     | 1.x / 2.x         | 1.x / 2.x         | 6.0.x            | 3.0.x         |
-| 2022.0 (Turing)           | 0.1.0                  | 5.0.x                     | 1.x / 2.x         | 1.x / 2.x         | 6.0.x            | 3.0.x         |
-
 ### OpenSearch 3.x / 2.x client libraries
 
+| Spring Data Release Train | Spring Data OpenSearch | Spring Data Elasticsearch | OpenSearch Server | OpenSearch Client   | Spring Framework | Spring Boot     | ClientJDK Version     |
+|---------------------------|------------------------|----------------------------|-------------------|---------------------|------------------|----------------|-----------------------|
+| 2025.0                    | 2.0.x                  | 5.5.x                      | 2.x / 3.x         | 3.0.x and above     | 6.2.x            | 3.5.x          | 21+                   |
+| 2025.0                    | 1.8.x                  | 5.5.x                      | 1.x / 2.x / 3.x   | 2.10.x and above    | 6.2.x            | 3.5.x          | 17+                   |
+| 2025.0                    | 1.7.x                  | 5.5.x                      | 1.x / 2.x / 3.x   | 2.10.x and above    | 6.2.x            | 3.5.x          | 17+                   |
+| 2024.1                    | 1.6.x                  | 5.4.x                      | 1.x / 2.x         | 2.10.x and above    | 6.2.x            | 3.4.x          | 17+                   |
+| 2024.0                    | 1.5.x                  | 5.3.x                      | 1.x / 2.x         | 2.10.x and above    | 6.1.x            | 3.2.x / 3.3.x  | 17+                   |
+| 2023.1 (Vaughan)          | 1.4.x                  | 5.2.x                      | 1.x / 2.x         | 2.10.x and above    | 6.1.x            | 3.2.x          | 17+                   |
+| 2023.1 (Vaughan)          | 1.3.x                  | 5.2.x                      | 1.x / 2.x         | 2.7.x and above     | 6.1.x            | 3.2.x          | 17+                   |
+| 2023.0 (Ullman)           | 1.2.x                  | 5.1.x                      | 1.x / 2.x         | 2.7.x and above     | 6.0.x            | 3.1.x          | 17+                   |
+| 2022.0 (Turing)           | 1.1.x                  | 5.0.x                      | 1.x / 2.x         | 2.7.x and above     | 6.0.x            | 3.0.x          | 17+                   |
+| 2022.0 (Turing)           | 1.0.x                  | 5.0.x                      | 1.x / 2.x         | 1.x / 2.6.x         | 6.0.x            | 3.0.x          | 17+                   |
+| 2022.0 (Turing)           | 0.2.0                  | 5.0.x                      | 1.x / 2.x         | 1.x / 2.x           | 6.0.x            | 3.0.x          | 17+                   |
+| 2022.0 (Turing)           | 0.1.0                  | 5.0.x                      | 1.x / 2.x         | 1.x / 2.x           | 6.0.x            | 3.0.x          | 17+                   |
 
 Spring Data OpenSearch provides the possibility to use either `RestHighLevelCLient` or [OpenSearchClient](https://github.com/opensearch-project/opensearch-java) to connect to OpenSearch clusters. 
 


### PR DESCRIPTION
### Description
This change adds a new `JDK Version` column to the compatibility matrix in the documentation of Spring Data OpenSearch. It clarifies the **minimum required JDK version** for each version of the Spring Data OpenSearch library. 

This avoids confusion when users attempt to use incompatible versions (e.g. using Spring Data OpenSearch `2.0.x` with JDK 17, which causes `UnsupportedClassVersionError` due to Java class file version 65).

#### Technical Evidence

To verify this requirement, we analyzed the compiled `.class` files using `javap -verbose`, which reveals the bytecode version of the classes:

```bash
/mnt/c/U/o/.m2/r/org/opensearch/client/spring-data-opensearch/2.0.0 ❯ jar xf spring-data-opensearch-2.0.0.jar org/opensearch/data/client/osc/NativeQuery.class
/mnt/c/U/o/.m2/r/org/opensearch/client/spring-data-opensearch/2.0.0 ❯ javap -verbose org/opensearch/data/client/osc/NativeQuery.class | grep "major version"
major version: 65
```

```bash
/mnt/c/U/o/.m2/r/org/opens/client/spring-data-opensearch/1.8.1 ❯ jar xf spring-data-opensearch-1.8.1.jar org/opensearch/data/client/osc/NativeQuery.class
/mnt/c/U/o/.m2/r/org/opens/client/spring-data-opensearch/1.8.1 ❯ javap -verbose org/opensearch/data/client/osc/NativeQuery.class | grep "major version"
major version: 61
```

## Benefits

The change improves developer experience by making version alignment between:

* Spring Data OpenSearch
* OpenSearch Java Client  
* Spring Boot
* **JDK versions**

more explicit and easier to understand.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
