### PR TITLE
don't ignore indices options for multi-search queries

### DIFF
--- a/spring-data-opensearch/src/main/java/org/opensearch/data/client/osc/RequestConverter.java
+++ b/spring-data-opensearch/src/main/java/org/opensearch/data/client/osc/RequestConverter.java
@@ -1433,6 +1433,10 @@ class RequestConverter {
                 h.preference(query.getPreference());
             }
 
+            if (query.getIndicesOptions() != null) {
+                addMultiSearchIndicesOptions(h, query.getIndicesOptions());
+            }
+
             return h;
         };
     }
@@ -1598,6 +1602,32 @@ class RequestConverter {
                 case IGNORE_THROTTLED -> builder.ignoreThrottled(true);
                 // the following ones aren't supported by the builder
                 case FORBID_ALIASES_TO_MULTIPLE_INDICES, FORBID_CLOSED_INDICES, IGNORE_ALIASES -> {
+                    if (LOGGER.isWarnEnabled()) {
+                        LOGGER
+                                .warn(String.format("indices option %s is not supported by the Elasticsearch client.", option.name()));
+                    }
+                }
+            }
+        });
+
+        builder.expandWildcards(indicesOptions.getExpandWildcards().stream()
+                .map(wildcardStates -> switch (wildcardStates) {
+                    case OPEN -> ExpandWildcard.Open;
+                    case CLOSED -> ExpandWildcard.Closed;
+                    case HIDDEN -> ExpandWildcard.Hidden;
+                    case ALL -> ExpandWildcard.All;
+                    case NONE -> ExpandWildcard.None;
+                }).collect(Collectors.toList()));
+    }
+
+    private void addMultiSearchIndicesOptions(MultisearchHeader.Builder builder, IndicesOptions indicesOptions) {
+
+        indicesOptions.getOptions().forEach(option -> {
+            switch (option) {
+                case ALLOW_NO_INDICES -> builder.allowNoIndices(true);
+                case IGNORE_UNAVAILABLE -> builder.ignoreUnavailable(true);
+                // the following ones aren't supported by the builder
+                case IGNORE_THROTTLED, FORBID_ALIASES_TO_MULTIPLE_INDICES, FORBID_CLOSED_INDICES, IGNORE_ALIASES -> {
                     if (LOGGER.isWarnEnabled()) {
                         LOGGER
                                 .warn(String.format("indices option %s is not supported by the Elasticsearch client.", option.name()));

--- a/spring-data-opensearch/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchIntegrationTests.java
+++ b/spring-data-opensearch/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchIntegrationTests.java
@@ -1729,6 +1729,23 @@ public abstract class ElasticsearchIntegrationTests {
 	}
 
 	@Test
+	public void shouldTakeIntoAccountIndicesOptionsForMultiSearch() {
+
+		Query query = getBuilderWithMatchAllQuery()
+				.withIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN)
+				.build();
+
+		List<SearchHits<Void>> searchHits = operations.multiSearch(List.of(query), Void.class,
+				IndexCoordinates.of("not-existing-index"));
+
+		assertThat(searchHits).hasSize(1)
+				.first()
+				.satisfies(hit -> {
+					assertThat(hit.getTotalHits()).isZero();
+				});
+	}
+
+	@Test
 	public void shouldIndexDocumentForSpecifiedSource() {
 
 		// given


### PR DESCRIPTION
### Description
Handles IndicesOptions for multi-search query in similar way how its done for regular search query.

### Issues Resolved
resolves #513 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
