### PR TITLE
[Backport] [1.7.x] don't ignore indices options for multi-search queries

### DIFF
--- a/spring-data-opensearch/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchIntegrationTests.java
+++ b/spring-data-opensearch/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchIntegrationTests.java
@@ -1724,6 +1724,23 @@ public abstract class ElasticsearchIntegrationTests {
 	}
 
 	@Test
+	public void shouldTakeIntoAccountIndicesOptionsForMultiSearch() {
+
+		Query query = getBuilderWithMatchAllQuery()
+				.withIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN)
+				.build();
+
+		List<SearchHits<Void>> searchHits = operations.multiSearch(List.of(query), Void.class,
+				IndexCoordinates.of("not-existing-index"));
+
+		assertThat(searchHits).hasSize(1)
+				.first()
+				.satisfies(hit -> {
+					assertThat(hit.getTotalHits()).isZero();
+				});
+	}
+
+	@Test
 	public void shouldIndexDocumentForSpecifiedSource() {
 
 		// given


### PR DESCRIPTION
Backport of #516 to 1.7.x