### PR TITLE
[Backport] [1.6.x] don't ignore indices options for multi-search queries

### DIFF
--- a/spring-data-opensearch/src/main/java/org/opensearch/data/client/osc/RequestConverter.java
+++ b/spring-data-opensearch/src/main/java/org/opensearch/data/client/osc/RequestConverter.java
@@ -1392,6 +1392,10 @@ class RequestConverter {
                 h.preference(query.getPreference());
             }
 
+            if (query.getIndicesOptions() != null) {
+                addMultiSearchIndicesOptions(h, query.getIndicesOptions());
+            }
+
             return h;
         };
     }
@@ -1550,6 +1554,32 @@ class RequestConverter {
                 case IGNORE_THROTTLED -> builder.ignoreThrottled(true);
                 // the following ones aren't supported by the builder
                 case FORBID_ALIASES_TO_MULTIPLE_INDICES, FORBID_CLOSED_INDICES, IGNORE_ALIASES -> {
+                    if (LOGGER.isWarnEnabled()) {
+                        LOGGER
+                                .warn(String.format("indices option %s is not supported by the Elasticsearch client.", option.name()));
+                    }
+                }
+            }
+        });
+
+        builder.expandWildcards(indicesOptions.getExpandWildcards().stream()
+                .map(wildcardStates -> switch (wildcardStates) {
+                    case OPEN -> ExpandWildcard.Open;
+                    case CLOSED -> ExpandWildcard.Closed;
+                    case HIDDEN -> ExpandWildcard.Hidden;
+                    case ALL -> ExpandWildcard.All;
+                    case NONE -> ExpandWildcard.None;
+                }).collect(Collectors.toList()));
+    }
+
+    private void addMultiSearchIndicesOptions(MultisearchHeader.Builder builder, IndicesOptions indicesOptions) {
+
+        indicesOptions.getOptions().forEach(option -> {
+            switch (option) {
+                case ALLOW_NO_INDICES -> builder.allowNoIndices(true);
+                case IGNORE_UNAVAILABLE -> builder.ignoreUnavailable(true);
+                // the following ones aren't supported by the builder
+                case IGNORE_THROTTLED, FORBID_ALIASES_TO_MULTIPLE_INDICES, FORBID_CLOSED_INDICES, IGNORE_ALIASES -> {
                     if (LOGGER.isWarnEnabled()) {
                         LOGGER
                                 .warn(String.format("indices option %s is not supported by the Elasticsearch client.", option.name()));

--- a/spring-data-opensearch/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchIntegrationTests.java
+++ b/spring-data-opensearch/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchIntegrationTests.java
@@ -1720,6 +1720,23 @@ public abstract class ElasticsearchIntegrationTests {
 	}
 
 	@Test
+	public void shouldTakeIntoAccountIndicesOptionsForMultiSearch() {
+
+		Query query = getBuilderWithMatchAllQuery()
+				.withIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN)
+				.build();
+
+		List<SearchHits<Void>> searchHits = operations.multiSearch(List.of(query), Void.class,
+				IndexCoordinates.of("not-existing-index"));
+
+		assertThat(searchHits).hasSize(1)
+				.first()
+				.satisfies(hit -> {
+					assertThat(hit.getTotalHits()).isZero();
+				});
+	}
+
+	@Test
 	public void shouldIndexDocumentForSpecifiedSource() {
 
 		// given


### PR DESCRIPTION
Backport of #516 to 1.6.x