### PR TITLE
Add JDK-25 to GA and fix integration test runs

### DIFF
--- a/.github/workflows/main_and_pr_workflow.yml
+++ b/.github/workflows/main_and_pr_workflow.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java-version: [21, 24]
+        java-version: [21, 25]
         runs-on: [ubuntu-latest]
     name: Assemble on ${{ matrix.runs-on }} with JDK ${{ matrix.java-version }}
     runs-on: ${{ matrix.runs-on }}
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java-version }}
-          distribution: 'temurin'
+          distribution: 'oracle'
           cache: gradle
       - name: Assemble with Gradle
         run: ./gradlew assemble
@@ -32,11 +32,11 @@ jobs:
         entry:
           - { opensearch-version: 2.11.0, java-version: 21 }
           - { opensearch-version: 2.19.2, java-version: 21 }
-          - { opensearch-version: 2.19.2, java-version: 24 }
+          - { opensearch-version: 2.19.2, java-version: 25 }
           - { opensearch-version: 3.0.0,  java-version: 21 }
-          - { opensearch-version: 3.0.0,  java-version: 24 }
+          - { opensearch-version: 3.0.0,  java-version: 25 }
           - { opensearch-version: 3.2.0,  java-version: 21 }
-          - { opensearch-version: 3.2.0,  java-version: 24 }
+          - { opensearch-version: 3.2.0,  java-version: 25 }
         runs-on: [ubuntu-latest]
     name: Check on ${{ matrix.runs-on }} with JDK ${{ matrix.entry.java-version }} against OpenSearch ${{ matrix.entry.opensearch-version }}
     runs-on: ${{ matrix.runs-on }}
@@ -47,7 +47,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.entry.java-version }}
-          distribution: 'temurin'
+          distribution: 'oracle'
           cache: gradle
       - name: Check with Gradle
         run: ./gradlew check -Psde.testcontainers.image-version=${{ matrix.entry.opensearch-version }}

--- a/buildSrc/src/main/kotlin/java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-conventions.gradle.kts
@@ -139,7 +139,10 @@ val integrationTestTask = tasks.register<Test>("integrationTest") {
 
   shouldRunAfter(tasks.test)
   jvmArgs("-XX:+AllowRedefinitionToAddDeleteMethods")
-  
+
+  testClassesDirs = sourceSets["test"].output.classesDirs
+  classpath = sourceSets["test"].runtimeClasspath
+
   systemProperty("sde.integration-test.environment", "opensearch")
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,4 @@ org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAME
   --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
   --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 
-sde.testcontainers.image-version=3.1.0
+sde.testcontainers.image-version=3.2.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionSha256Sum=8fad3d78296ca518113f3d29016617c7f9367dc005f932bd9d93bf45ba46072b
+distributionSha256Sum=a17ddd85a26b6a7f5ddb71ff8b05fc5104c0202c6e64782429790c933686c806

--- a/gradlew
+++ b/gradlew
@@ -114,7 +114,6 @@ case "$( uname )" in                #(
   NONSTOP* )        nonstop=true ;;
 esac
 
-CLASSPATH="\\\"\\\""
 
 
 # Determine the Java command to use to start the JVM.
@@ -172,7 +171,6 @@ fi
 # For Cygwin or MSYS, switch paths to Windows format before running java
 if "$cygwin" || "$msys" ; then
     APP_HOME=$( cygpath --path --mixed "$APP_HOME" )
-    CLASSPATH=$( cygpath --path --mixed "$CLASSPATH" )
 
     JAVACMD=$( cygpath --unix "$JAVACMD" )
 
@@ -212,7 +210,6 @@ DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 
 set -- \
         "-Dorg.gradle.appname=$APP_BASE_NAME" \
-        -classpath "$CLASSPATH" \
         -jar "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" \
         "$@"
 

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -70,11 +70,10 @@ goto fail
 :execute
 @rem Setup the command line
 
-set CLASSPATH=
 
 
 @rem Execute Gradle
-"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" -jar "%APP_HOME%\gradle\wrapper\gradle-wrapper.jar" %*
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -jar "%APP_HOME%\gradle\wrapper\gradle-wrapper.jar" %*
 
 :end
 @rem End local scope for the variables with windows NT shell

--- a/spring-data-opensearch-docker-compose/src/test/java/org/opensearch/spring/boot/docker/compose/service/connection/OpenSearchDockerComposeConnectionDetailsFactoryTest.java
+++ b/spring-data-opensearch-docker-compose/src/test/java/org/opensearch/spring/boot/docker/compose/service/connection/OpenSearchDockerComposeConnectionDetailsFactoryTest.java
@@ -38,7 +38,7 @@ class OpenSearchDockerComposeConnectionDetailsFactoryTest {
         try (InputStream input = response.getEntity().getContent()) {
             JsonNode result = new ObjectMapper().readTree(input);
             assertThat(result.path("version").path("number").asText())
-                    .isEqualTo("3.1.0");
+                    .isEqualTo("3.2.0");
         }
     }
 

--- a/spring-data-opensearch-docker-compose/src/test/java/org/opensearch/spring/boot/docker/compose/service/connection/SecureOpenSearchDockerComposeConnectionDetailsFactoryTest.java
+++ b/spring-data-opensearch-docker-compose/src/test/java/org/opensearch/spring/boot/docker/compose/service/connection/SecureOpenSearchDockerComposeConnectionDetailsFactoryTest.java
@@ -51,7 +51,7 @@ class SecureOpenSearchDockerComposeConnectionDetailsFactoryTest {
         try (InputStream input = response.getEntity().getContent()) {
             JsonNode result = new ObjectMapper().readTree(input);
             assertThat(result.path("version").path("number").asText())
-                    .isEqualTo("3.1.0");
+                    .isEqualTo("3.2.0");
         }
     }
 

--- a/spring-data-opensearch-docker-compose/src/test/resources/org/opensearch/spring/boot/docker/compose/service/connection/opensearch-compose.yaml
+++ b/spring-data-opensearch-docker-compose/src/test/resources/org/opensearch/spring/boot/docker/compose/service/connection/opensearch-compose.yaml
@@ -1,6 +1,6 @@
 services:
   opensearch:
-    image: opensearchproject/opensearch:3.1.0
+    image: opensearchproject/opensearch:3.2.0
     ports:
       - '9200'
     environment:

--- a/spring-data-opensearch-docker-compose/src/test/resources/org/opensearch/spring/boot/docker/compose/service/connection/secure-opensearch-compose.yaml
+++ b/spring-data-opensearch-docker-compose/src/test/resources/org/opensearch/spring/boot/docker/compose/service/connection/secure-opensearch-compose.yaml
@@ -1,6 +1,6 @@
 services:
   opensearch:
-    image: opensearchproject/opensearch:3.1.0
+    image: opensearchproject/opensearch:3.2.0
     ports:
       - '9200'
     healthcheck:


### PR DESCRIPTION
### Description
Add JDK-25 to GA and fix integration test runs

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
