### PR TITLE
Onboarding new maven snapshots publishing to s3 (spring-data-opensearch)

### DIFF
--- a/.github/workflows/publish-snapshots.yml
+++ b/.github/workflows/publish-snapshots.yml
@@ -26,8 +26,13 @@ jobs:
           export-env: true
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          SONATYPE_USERNAME: op://opensearch-infra-secrets/maven-central-portal-credentials/username
-          SONATYPE_PASSWORD: op://opensearch-infra-secrets/maven-central-portal-credentials/password
+          MAVEN_SNAPSHOTS_S3_REPO: op://opensearch-infra-secrets/maven-snapshots-s3/repo
+          MAVEN_SNAPSHOTS_S3_ROLE: op://opensearch-infra-secrets/maven-snapshots-s3/role
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          role-to-assume: ${{ env.MAVEN_SNAPSHOTS_S3_ROLE }}
+          aws-region: us-east-1
       - name: publish snapshots to Apache Maven repositories
         run: |
           ./gradlew --no-daemon publishPublishMavenPublicationToSnapshotsRepository

--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ If you'd rather like the latest snapshots of the upcoming major version, use our
 <repository>
   <id>opensearch-libs-snapshot</id>
   <name>AWS Snapshot Repository</name>
-  <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+  <url>https://ci.opensearch.org/ci/dbc/snapshots/maven/</url>
 </repository>
 ```
 
@@ -387,7 +387,7 @@ dependencies {
 repositories {
   ...
   maven {
-    url = "https://central.sonatype.com/repository/maven-snapshots/"
+    url = "https://ci.opensearch.org/ci/dbc/snapshots/maven/"
   }
   ...
 }

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -41,4 +41,4 @@ The release process is standard across repositories in this org and is run by a 
 1. Increment "version" in [version.properties](./version.properties) to the next iteration, e.g. v2.1.1. See [example](https://github.com/opensearch-project/spring-data-opensearch/pull/75).
 
 ## Snapshot Builds
-The [snapshots builds](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/org/opensearch/client/spring-data-opensearch/) are published to sonatype using [publish-snapshots.yml](./.github/workflows/publish-snapshots.yml) workflow. Each `push` event to the main branch triggers this workflow.
+The [snapshots builds](https://ci.opensearch.org/ci/dbc/snapshots/maven/org/opensearch/client/spring-data-opensearch/) are published to sonatype using [publish-snapshots.yml](./.github/workflows/publish-snapshots.yml) workflow. Each `push` event to the main branch triggers this workflow.

--- a/buildSrc/src/main/kotlin/java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-conventions.gradle.kts
@@ -111,11 +111,12 @@ tasks.test {
 publishing {
   repositories {
     if (version.toString().endsWith("SNAPSHOT")) {
-      maven("https://central.sonatype.com/repository/maven-snapshots/") {
+      maven(providers.environmentVariable("MAVEN_SNAPSHOTS_S3_REPO")) {
         name = "Snapshots"
-        credentials {
-            username = System.getenv("SONATYPE_USERNAME")
-            password = System.getenv("SONATYPE_PASSWORD")
+        credentials(AwsCredentials::class) {
+          accessKey = System.getenv("AWS_ACCESS_KEY_ID")
+          secretKey = System.getenv("AWS_SECRET_ACCESS_KEY")
+          sessionToken = System.getenv("AWS_SESSION_TOKEN")
         }
       }
     }


### PR DESCRIPTION
### Description
Onboarding new maven snapshots publishing to s3 (spring-data-opensearch)

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/5360

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
