### PR TITLE
spring-configuration-metadata support for spring-data-opensearch-star…

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -27,6 +27,7 @@ dependencyResolutionManagement {
       library("boot-web", "org.springframework.boot", "spring-boot-starter-web").versionRef("spring-boot")
       library("boot-webflux", "org.springframework.boot", "spring-boot-starter-webflux").versionRef("spring-boot")
       library("boot-autoconfigure", "org.springframework.boot", "spring-boot-autoconfigure").versionRef("spring-boot")
+      library("boot-configuration-processor", "org.springframework.boot", "spring-boot-configuration-processor").versionRef("spring-boot")
       library("boot-docker-compose", "org.springframework.boot", "spring-boot-docker-compose").versionRef("spring-boot")
       library("boot-elasticsearch", "org.springframework.boot", "spring-boot-elasticsearch").versionRef("spring-boot")
       library("boot-data-elasticsearch", "org.springframework.boot", "spring-boot-data-elasticsearch").versionRef("spring-boot")

--- a/spring-data-opensearch-starter/build.gradle.kts
+++ b/spring-data-opensearch-starter/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
   }
   compileOnly(opensearchLibs.java.client)
   compileOnly(jakarta.json.bind)
+  annotationProcessor(springLibs.boot.configuration.processor)
   testImplementation(springLibs.test) {
     exclude("ch.qos.logback", "logback-classic")
   }


### PR DESCRIPTION
…ter (closes #615)

### Description
This PR that adds [`@ConfigurationProperties` metadata](https://docs.spring.io/spring-boot/specification/configuration-metadata/annotation-processor.html) generation to the build of spring-data-opensearch-starter (which is the only library built within this project declaring @ConfigurationProperties).

I haven't explicitly documented this as exposing these metadata is a de-facto best-practice in the Spring Boot ecosystem.

### Issues Resolved
- #615 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
