### PR TITLE
Support knn_vector field type

### DIFF
--- a/.github/workflows/main_and_pr_workflow.yml
+++ b/.github/workflows/main_and_pr_workflow.yml
@@ -30,7 +30,6 @@ jobs:
       fail-fast: false
       matrix:
         entry:
-          - { opensearch-version: 2.11.0, java-version: 21 }
           - { opensearch-version: 2.19.2, java-version: 21 }
           - { opensearch-version: 2.19.2, java-version: 25 }
           - { opensearch-version: 3.0.0,  java-version: 21 }

--- a/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/OpenSearchClientAutoConfiguration.java
+++ b/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/OpenSearchClientAutoConfiguration.java
@@ -8,6 +8,7 @@ import org.opensearch.client.RestClient;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.spring.boot.autoconfigure.OpenSearchClientConfigurations.JsonpMapperConfiguration;
 import org.opensearch.spring.boot.autoconfigure.OpenSearchClientConfigurations.OpenSearchClientConfiguration;
+import org.opensearch.spring.boot.autoconfigure.OpenSearchClientConfigurations.OpenSearchMappingParametersCustomizerConfiguration;
 import org.opensearch.spring.boot.autoconfigure.OpenSearchClientConfigurations.OpenSearchTransportConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -22,6 +23,6 @@ import org.springframework.context.annotation.Import;
     afterName = { "org.springframework.boot.jsonb.autoconfigure.JsonbAutoConfiguration" })
 @ConditionalOnBean(RestClient.class)
 @ConditionalOnClass(OpenSearchClient.class)
-@Import({ JsonpMapperConfiguration.class, OpenSearchTransportConfiguration.class, OpenSearchClientConfiguration.class })
+@Import({ JsonpMapperConfiguration.class, OpenSearchTransportConfiguration.class, OpenSearchClientConfiguration.class, OpenSearchMappingParametersCustomizerConfiguration.class })
 public class OpenSearchClientAutoConfiguration {
 }

--- a/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/OpenSearchClientConfigurations.java
+++ b/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/OpenSearchClientConfigurations.java
@@ -15,6 +15,7 @@ import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.transport.OpenSearchTransport;
 import org.opensearch.client.transport.rest_client.RestClientOptions;
 import org.opensearch.client.transport.rest_client.RestClientTransport;
+import org.opensearch.data.core.OpenSearchMappingParametersCustomizer;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -66,6 +67,15 @@ class OpenSearchClientConfigurations {
         @ConditionalOnMissingBean
         OpenSearchClient opensearchClient(OpenSearchTransport transport) {
             return new OpenSearchClient(transport);
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class OpenSearchMappingParametersCustomizerConfiguration {
+        @Bean
+        @ConditionalOnMissingBean
+        OpenSearchMappingParametersCustomizer opensearchMappingParametersCustomizer() {
+            return new OpenSearchMappingParametersCustomizer();
         }
     }
 }

--- a/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/OpenSearchRestHighLevelClientConfigurations.java
+++ b/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/OpenSearchRestHighLevelClientConfigurations.java
@@ -13,6 +13,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.elasticsearch.core.convert.ElasticsearchCustomConversions;
+import org.springframework.data.elasticsearch.core.index.MappingParametersCustomizer;
 
 /**
  * OpenSearch REST High LeveL client configurations.
@@ -39,6 +40,13 @@ class OpenSearchRestHighLevelClientConfigurations {
         @Override
         public ElasticsearchCustomConversions elasticsearchCustomConversions() {
             return super.elasticsearchCustomConversions();
+        }
+
+        @Bean
+        @ConditionalOnMissingBean
+        @Override
+        public MappingParametersCustomizer opensearchMappingParametersCustomizer() {
+            return super.opensearchMappingParametersCustomizer();
         }
     }
 }

--- a/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/data/OpenSearchDataConfiguration.java
+++ b/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/data/OpenSearchDataConfiguration.java
@@ -23,6 +23,7 @@ import org.springframework.data.elasticsearch.core.ReactiveElasticsearchOperatio
 import org.springframework.data.elasticsearch.core.convert.ElasticsearchConverter;
 import org.springframework.data.elasticsearch.core.convert.ElasticsearchCustomConversions;
 import org.springframework.data.elasticsearch.core.convert.MappingElasticsearchConverter;
+import org.springframework.data.elasticsearch.core.index.MappingParametersCustomizer;
 import org.springframework.data.elasticsearch.core.mapping.SimpleElasticsearchMappingContext;
 
 /**
@@ -74,8 +75,8 @@ abstract class OpenSearchDataConfiguration {
         @Bean
         @ConditionalOnMissingBean(value = ElasticsearchOperations.class, name = { "elasticsearchTemplate", "opensearchTemplate" })
         @ConditionalOnBean(OpenSearchClient.class)
-        OpenSearchTemplate elasticsearchTemplate(OpenSearchClient client, ElasticsearchConverter converter) {
-            return new OpenSearchTemplate(client, converter);
+        OpenSearchTemplate elasticsearchTemplate(OpenSearchClient client, ElasticsearchConverter converter, MappingParametersCustomizer opensearchMappingParametersCustomizer) {
+            return new OpenSearchTemplate(client, converter, opensearchMappingParametersCustomizer);
         }
     }
 

--- a/spring-data-opensearch/src/main/java/org/opensearch/data/client/orhlc/AbstractOpenSearchConfiguration.java
+++ b/spring-data-opensearch/src/main/java/org/opensearch/data/client/orhlc/AbstractOpenSearchConfiguration.java
@@ -10,10 +10,12 @@
 package org.opensearch.data.client.orhlc;
 
 import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.data.core.OpenSearchMappingParametersCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.elasticsearch.config.ElasticsearchConfigurationSupport;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.convert.ElasticsearchConverter;
+import org.springframework.data.elasticsearch.core.index.MappingParametersCustomizer;
 
 /**
  * @see ElasticsearchConfigurationSupport
@@ -36,11 +38,16 @@ public abstract class AbstractOpenSearchConfiguration extends ElasticsearchConfi
      */
     @Bean(name = {"elasticsearchOperations", "elasticsearchTemplate", "opensearchTemplate"})
     public ElasticsearchOperations elasticsearchOperations(
-            ElasticsearchConverter elasticsearchConverter, RestHighLevelClient opensearchClient) {
+            ElasticsearchConverter elasticsearchConverter, RestHighLevelClient opensearchClient, MappingParametersCustomizer opensearchMappingParametersCustomizer) {
 
-        OpenSearchRestTemplate template = new OpenSearchRestTemplate(opensearchClient, elasticsearchConverter);
+        OpenSearchRestTemplate template = new OpenSearchRestTemplate(opensearchClient, elasticsearchConverter, opensearchMappingParametersCustomizer);
         template.setRefreshPolicy(refreshPolicy());
 
         return template;
+    }
+
+    @Bean
+    public MappingParametersCustomizer opensearchMappingParametersCustomizer() {
+        return new OpenSearchMappingParametersCustomizer();
     }
 }

--- a/spring-data-opensearch/src/main/java/org/opensearch/data/client/orhlc/OpenSearchRestTemplate.java
+++ b/spring-data-opensearch/src/main/java/org/opensearch/data/client/orhlc/OpenSearchRestTemplate.java
@@ -45,6 +45,7 @@ import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.client.RestHighLevelClient;
 import org.opensearch.common.unit.TimeValue;
+import org.opensearch.data.core.OpenSearchMappingParametersCustomizer;
 import org.opensearch.data.core.OpenSearchOperations;
 import org.opensearch.index.query.MoreLikeThisQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
@@ -63,6 +64,7 @@ import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.data.elasticsearch.core.SearchScrollHits;
 import org.springframework.data.elasticsearch.core.cluster.ClusterOperations;
 import org.springframework.data.elasticsearch.core.convert.ElasticsearchConverter;
+import org.springframework.data.elasticsearch.core.index.MappingParametersCustomizer;
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.data.elasticsearch.core.query.BaseQueryBuilder;
 import org.springframework.data.elasticsearch.core.query.BulkOptions;
@@ -90,6 +92,7 @@ public class OpenSearchRestTemplate extends AbstractElasticsearchTemplate implem
 
     private final RestHighLevelClient client;
     private final OpenSearchExceptionTranslator exceptionTranslator = new OpenSearchExceptionTranslator();
+    private final MappingParametersCustomizer mappingParametersCustomizer;
     protected RequestFactory requestFactory;
 
     // region _initialization
@@ -99,27 +102,33 @@ public class OpenSearchRestTemplate extends AbstractElasticsearchTemplate implem
 
         this.client = client;
         requestFactory = new RequestFactory(this.elasticsearchConverter);
+        mappingParametersCustomizer = new OpenSearchMappingParametersCustomizer();
     }
 
-    public OpenSearchRestTemplate(RestHighLevelClient client, ElasticsearchConverter opensearchConverter) {
+    public OpenSearchRestTemplate(RestHighLevelClient client, ElasticsearchConverter opensearchConverter, MappingParametersCustomizer mappingParametersCustomizer) {
 
         super(opensearchConverter);
 
         Assert.notNull(client, "Client must not be null!");
 
         this.client = client;
-        requestFactory = new RequestFactory(this.elasticsearchConverter);
+        this.requestFactory = new RequestFactory(this.elasticsearchConverter);
+        this.mappingParametersCustomizer = mappingParametersCustomizer;
     }
 
     @Override
     protected AbstractElasticsearchTemplate doCopy() {
-        OpenSearchRestTemplate copy = new OpenSearchRestTemplate(client, elasticsearchConverter);
+        OpenSearchRestTemplate copy = new OpenSearchRestTemplate(client, elasticsearchConverter, mappingParametersCustomizer);
         copy.requestFactory = this.requestFactory;
         return copy;
     }
 
     public RequestFactory getRequestFactory() {
         return requestFactory;
+    }
+
+    public MappingParametersCustomizer getMappingParametersCustomizer() {
+        return mappingParametersCustomizer;
     }
 
     // endregion

--- a/spring-data-opensearch/src/main/java/org/opensearch/data/client/orhlc/RestIndexTemplate.java
+++ b/spring-data-opensearch/src/main/java/org/opensearch/data/client/orhlc/RestIndexTemplate.java
@@ -68,13 +68,13 @@ class RestIndexTemplate extends AbstractIndexTemplate implements IndexOperations
     protected final RequestFactory requestFactory;
 
     public RestIndexTemplate(OpenSearchRestTemplate restTemplate, Class<?> boundClass) {
-        super(restTemplate.getElasticsearchConverter(), boundClass);
+        super(restTemplate.getElasticsearchConverter(), restTemplate.getMappingParametersCustomizer(), boundClass);
         this.restTemplate = restTemplate;
         requestFactory = new RequestFactory(elasticsearchConverter);
     }
 
     public RestIndexTemplate(OpenSearchRestTemplate restTemplate, IndexCoordinates boundIndex) {
-        super(restTemplate.getElasticsearchConverter(), boundIndex);
+        super(restTemplate.getElasticsearchConverter(), restTemplate.getMappingParametersCustomizer(), boundIndex);
         this.restTemplate = restTemplate;
         requestFactory = new RequestFactory(elasticsearchConverter);
     }

--- a/spring-data-opensearch/src/main/java/org/opensearch/data/client/orhlc/knn/KnnQueryBuilder.java
+++ b/spring-data-opensearch/src/main/java/org/opensearch/data/client/orhlc/knn/KnnQueryBuilder.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.data.client.orhlc.knn;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import org.apache.lucene.search.Query;
+import org.opensearch.core.ParseField;
+import org.opensearch.core.common.Strings;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.index.query.AbstractQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.index.query.WithFieldName;
+
+public class KnnQueryBuilder extends AbstractQueryBuilder<KnnQueryBuilder> implements WithFieldName {
+    public static final String METHOD_PARAMETER_EF_SEARCH = "ef_search";
+    public static final String METHOD_PARAMETER_M = "m";
+    public static final String METHOD_PARAMETER = "method_parameters";
+    public static final String NAME = "knn";
+    public static final int K_MAX = 10000;
+
+    public static final ParseField VECTOR_FIELD = new ParseField("vector");
+    public static final ParseField K_FIELD = new ParseField("k");
+    public static final ParseField FILTER_FIELD = new ParseField("filter");
+    public static final ParseField IGNORE_UNMAPPED_FIELD = new ParseField("ignore_unmapped");
+    public static final ParseField EF_SEARCH_FIELD = new ParseField(METHOD_PARAMETER_EF_SEARCH);
+
+    private final String fieldName;
+    private final float[] vector;
+    private Integer k;
+    private QueryBuilder filter;
+    private boolean ignoreUnmapped;
+
+    private KnnQueryBuilder(final String fieldName, final float[] vector, final Integer k, final QueryBuilder filter, final boolean ignoreUnmapped) {
+        this.fieldName = fieldName;
+        this.vector = vector;
+        this.k = k;
+        this.filter = filter;
+        this.ignoreUnmapped = ignoreUnmapped;
+    }
+
+    public static class Builder {
+        private String fieldName;
+        private float[] vector;
+        private Integer k;
+        private QueryBuilder filter;
+        private boolean ignoreUnmapped;
+        private String queryName;
+        private float boost = DEFAULT_BOOST;
+
+        public Builder() {}
+
+        public Builder field(String fieldName) {
+            return fieldName(fieldName);
+        }
+
+        public Builder fieldName(String fieldName) {
+            this.fieldName = fieldName;
+            return this;
+        }
+
+        public Builder vector(List<Float> vector) {
+            final float[] values = new float [vector.size()];
+            for (int i = 0; i < vector.size(); ++i) {
+                values[i] = vector.get(i).floatValue();
+            }
+            return vector(values);
+        }
+
+        public Builder vector(float[] vector) {
+            this.vector = vector;
+            return this;
+        }
+
+        public Builder k(Integer k) {
+            this.k = k;
+            return this;
+        }
+
+        public Builder ignoreUnmapped(boolean ignoreUnmapped) {
+            this.ignoreUnmapped = ignoreUnmapped;
+            return this;
+        }
+
+        public Builder filter(QueryBuilder filter) {
+            this.filter = filter;
+            return this;
+        }
+
+        public Builder queryName(String queryName) {
+            this.queryName = queryName;
+            return this;
+        }
+
+        public Builder boost(float boost) {
+            this.boost = boost;
+            return this;
+        }
+
+        public KnnQueryBuilder build() {
+            validate();
+            return new KnnQueryBuilder(
+                fieldName,
+                vector,
+                k,
+                filter,
+                ignoreUnmapped
+            ).boost(boost).queryName(queryName);
+        }
+
+        private void validate() {
+            if (Strings.isNullOrEmpty(fieldName)) {
+                throw new IllegalArgumentException(String.format(Locale.ROOT, "[%s] requires fieldName", NAME));
+            }
+
+            if (vector == null) {
+                throw new IllegalArgumentException(String.format(Locale.ROOT, "[%s] requires query vector", NAME));
+            } else if (vector.length == 0) {
+                throw new IllegalArgumentException(String.format(Locale.ROOT, "[%s] query vector is empty", NAME));
+            }
+
+
+            if (k != null) {
+                if (k <= 0 || k > K_MAX) {
+                    final String errorMessage = "[" + NAME + "] requires k to be in the range (0, " + K_MAX + "]";
+                    throw new IllegalArgumentException(errorMessage);
+                }
+            }
+        }
+    }
+
+    public float[] getVector() {
+        return vector;
+    }
+
+    public Integer getK() {
+        return k;
+    }
+
+    public QueryBuilder getFilter() {
+        return filter;
+    }
+
+    public boolean isIgnoreUnmapped() {
+        return ignoreUnmapped;
+    }
+
+    @Override
+    protected void doXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(NAME);
+        builder.startObject(this.fieldName());
+
+        builder.field(VECTOR_FIELD.getPreferredName(), this.getVector());
+
+        if (this.getK() != null) {
+            builder.field(K_FIELD.getPreferredName(), this.getK());
+        }
+        if (this.getFilter() != null) {
+            builder.field(FILTER_FIELD.getPreferredName(), this.getFilter());
+        }
+
+        if (this.isIgnoreUnmapped()) {
+            builder.field(IGNORE_UNMAPPED_FIELD.getPreferredName(), this.isIgnoreUnmapped());
+        }
+
+        builder.field(BOOST_FIELD.getPreferredName(), this.boost());
+        if (this.queryName() != null) {
+            builder.field(NAME_FIELD.getPreferredName(), this.queryName());
+        }
+
+        builder.endObject();
+        builder.endObject();
+    }
+
+    public static KnnQueryBuilder.Builder builder() {
+        return new KnnQueryBuilder.Builder();
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+
+    @Override
+    public String fieldName() {
+        return fieldName;
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        throw new UnsupportedOperationException("The doWriteTo is not supported");
+    }
+
+    @Override
+    protected Query doToQuery(QueryShardContext context) throws IOException {
+        throw new UnsupportedOperationException("The doToQuery is not supported");
+    }
+
+    @Override
+    protected boolean doEquals(KnnQueryBuilder other) {
+        return Objects.equals(fieldName, other.fieldName)
+            && Arrays.equals(vector, other.vector)
+            && Objects.equals(k, other.k)
+            && Objects.equals(filter, other.filter)
+            && Objects.equals(ignoreUnmapped, other.ignoreUnmapped);
+    }
+
+    @Override
+    protected int doHashCode() {
+        return Objects.hash(
+            fieldName,
+            Arrays.hashCode(vector),
+            k,
+            filter,
+            ignoreUnmapped
+        );
+    }
+
+}

--- a/spring-data-opensearch/src/main/java/org/opensearch/data/client/osc/IndicesTemplate.java
+++ b/spring-data-opensearch/src/main/java/org/opensearch/data/client/osc/IndicesTemplate.java
@@ -60,11 +60,12 @@ public class IndicesTemplate extends ChildTemplate<OpenSearchTransport, OpenSear
     // (component templates)
     private final ClusterTemplate clusterTemplate;
     protected final ElasticsearchConverter elasticsearchConverter;
+    protected final MappingParametersCustomizer mappingParametersCustomizer;
     @Nullable protected final Class<?> boundClass;
     @Nullable protected final IndexCoordinates boundIndex;
 
     public IndicesTemplate(OpenSearchIndicesClient client, ClusterTemplate clusterTemplate,
-            ElasticsearchConverter elasticsearchConverter, Class<?> boundClass) {
+            ElasticsearchConverter elasticsearchConverter, MappingParametersCustomizer mappingParametersCustomizer, Class<?> boundClass) {
         super(client, elasticsearchConverter);
 
         Assert.notNull(clusterTemplate, "cluster must not be null");
@@ -73,13 +74,14 @@ public class IndicesTemplate extends ChildTemplate<OpenSearchTransport, OpenSear
 
         this.clusterTemplate = clusterTemplate;
         this.elasticsearchConverter = elasticsearchConverter;
+        this.mappingParametersCustomizer = mappingParametersCustomizer;
         this.boundClass = boundClass;
         this.boundIndex = null;
 
     }
 
-    public IndicesTemplate(OpenSearchIndicesClient client, ClusterTemplate clusterTemplate,
-                                                 ElasticsearchConverter elasticsearchConverter, IndexCoordinates boundIndex) {
+    public IndicesTemplate(OpenSearchIndicesClient client, ClusterTemplate clusterTemplate, ElasticsearchConverter elasticsearchConverter,
+            MappingParametersCustomizer mappingParametersCustomizer, IndexCoordinates boundIndex) {
         super(client, elasticsearchConverter);
 
         Assert.notNull(clusterTemplate, "cluster must not be null");
@@ -88,6 +90,7 @@ public class IndicesTemplate extends ChildTemplate<OpenSearchTransport, OpenSear
 
         this.clusterTemplate = clusterTemplate;
         this.elasticsearchConverter = elasticsearchConverter;
+        this.mappingParametersCustomizer = mappingParametersCustomizer;
         this.boundClass = null;
         this.boundIndex = boundIndex;
 
@@ -206,7 +209,7 @@ public class IndicesTemplate extends ChildTemplate<OpenSearchTransport, OpenSear
 
         // build mapping from field annotations
         try {
-            String mapping = new MappingBuilder(elasticsearchConverter).buildPropertyMapping(clazz);
+            String mapping = new MappingBuilder(elasticsearchConverter, mappingParametersCustomizer).buildPropertyMapping(clazz);
             return Document.parse(mapping);
         } catch (Exception e) {
             throw new UncategorizedElasticsearchException("Failed to build mapping for " + clazz.getSimpleName(), e);

--- a/spring-data-opensearch/src/main/java/org/opensearch/data/client/osc/NativeQueryBuilder.java
+++ b/spring-data-opensearch/src/main/java/org/opensearch/data/client/osc/NativeQueryBuilder.java
@@ -224,6 +224,11 @@ public class NativeQueryBuilder extends BaseQueryBuilder<NativeQuery, NativeQuer
         return this;
     }
 
+    public NativeQueryBuilder withKnnQuery(Function<KnnQuery.Builder, ObjectBuilder<KnnQuery>> fn) {
+        Assert.notNull(fn, "fn must not be null");
+        return withKnnQuery(fn.apply(new KnnQuery.Builder()).build());
+    }
+
     public NativeQuery build() {
         Assert.isTrue(query == null || springDataQuery == null, "Cannot have both a native query and a Spring Data query");
         return new NativeQuery(this);

--- a/spring-data-opensearch/src/main/java/org/opensearch/data/client/osc/OpenSearchConfiguration.java
+++ b/spring-data-opensearch/src/main/java/org/opensearch/data/client/osc/OpenSearchConfiguration.java
@@ -23,11 +23,13 @@ import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.transport.OpenSearchTransport;
 import org.opensearch.client.transport.TransportOptions;
 import org.opensearch.client.transport.rest_client.RestClientOptions;
+import org.opensearch.data.core.OpenSearchMappingParametersCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.elasticsearch.client.ClientConfiguration;
 import org.springframework.data.elasticsearch.config.ElasticsearchConfigurationSupport;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.convert.ElasticsearchConverter;
+import org.springframework.data.elasticsearch.core.index.MappingParametersCustomizer;
 import org.springframework.util.Assert;
 
 /**
@@ -101,9 +103,9 @@ public abstract class OpenSearchConfiguration extends ElasticsearchConfiguration
      */
     @Bean(name = { "elasticsearchOperations", "elasticsearchTemplate", "opensearchOperations", "opensearchTemplate" })
     public ElasticsearchOperations opensearchOperations(ElasticsearchConverter elasticsearchConverter,
-            OpenSearchClient elasticsearchClient) {
+            OpenSearchClient elasticsearchClient, MappingParametersCustomizer opensearchMappingParametersCustomizer) {
 
-        OpenSearchTemplate template = new OpenSearchTemplate(elasticsearchClient, elasticsearchConverter);
+        OpenSearchTemplate template = new OpenSearchTemplate(elasticsearchClient, elasticsearchConverter, opensearchMappingParametersCustomizer);
         template.setRefreshPolicy(refreshPolicy());
 
         return template;
@@ -118,6 +120,11 @@ public abstract class OpenSearchConfiguration extends ElasticsearchConfiguration
     @Bean
     public JsonpMapper jsonpMapper() {
         return new JacksonJsonpMapper();
+    }
+
+    @Bean
+    public MappingParametersCustomizer opensearchMappingParametersCustomizer() {
+        return new OpenSearchMappingParametersCustomizer();
     }
 
     /**

--- a/spring-data-opensearch/src/main/java/org/opensearch/data/client/osc/OpenSearchTemplate.java
+++ b/spring-data-opensearch/src/main/java/org/opensearch/data/client/osc/OpenSearchTemplate.java
@@ -37,6 +37,7 @@ import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;
 import org.opensearch.client.opensearch.core.msearch.MultiSearchResponseItem;
 import org.opensearch.client.opensearch.core.search.SearchResult;
 import org.opensearch.client.transport.Version;
+import org.opensearch.data.core.OpenSearchMappingParametersCustomizer;
 import org.opensearch.data.core.OpenSearchOperations;
 import org.springframework.data.elasticsearch.BulkFailureException;
 import org.springframework.data.elasticsearch.client.UnsupportedBackendOperation;
@@ -50,6 +51,7 @@ import org.springframework.data.elasticsearch.core.cluster.ClusterOperations;
 import org.springframework.data.elasticsearch.core.convert.ElasticsearchConverter;
 import org.springframework.data.elasticsearch.core.document.Document;
 import org.springframework.data.elasticsearch.core.document.SearchDocumentResponse;
+import org.springframework.data.elasticsearch.core.index.MappingParametersCustomizer;
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.data.elasticsearch.core.query.BaseQueryBuilder;
 import org.springframework.data.elasticsearch.core.query.BulkOptions;
@@ -88,6 +90,7 @@ public class OpenSearchTemplate extends AbstractElasticsearchTemplate implements
     private final ResponseConverter responseConverter;
     private final JsonpMapper jsonpMapper;
     private final OpenSearchExceptionTranslator exceptionTranslator;
+    private final MappingParametersCustomizer mappingParametersCustomizer;
 
     // region _initialization
     public OpenSearchTemplate(OpenSearchClient client) {
@@ -99,35 +102,37 @@ public class OpenSearchTemplate extends AbstractElasticsearchTemplate implements
         requestConverter = new RequestConverter(elasticsearchConverter, jsonpMapper);
         responseConverter = new ResponseConverter(jsonpMapper);
         exceptionTranslator = new OpenSearchExceptionTranslator(jsonpMapper);
+        mappingParametersCustomizer = new OpenSearchMappingParametersCustomizer();
     }
 
-    public OpenSearchTemplate(OpenSearchClient client, ElasticsearchConverter elasticsearchConverter) {
+    public OpenSearchTemplate(OpenSearchClient client, ElasticsearchConverter elasticsearchConverter, MappingParametersCustomizer mappingParametersCustomizer) {
         super(elasticsearchConverter);
 
         Assert.notNull(client, "client must not be null");
 
         this.client = client;
         this.jsonpMapper = client._transport().jsonpMapper();
-        requestConverter = new RequestConverter(elasticsearchConverter, jsonpMapper);
-        responseConverter = new ResponseConverter(jsonpMapper);
-        exceptionTranslator = new OpenSearchExceptionTranslator(jsonpMapper);
+        this.requestConverter = new RequestConverter(elasticsearchConverter, jsonpMapper);
+        this.responseConverter = new ResponseConverter(jsonpMapper);
+        this.exceptionTranslator = new OpenSearchExceptionTranslator(jsonpMapper);
+        this.mappingParametersCustomizer = mappingParametersCustomizer;
     }
 
     @Override
     protected AbstractElasticsearchTemplate doCopy() {
-        return new OpenSearchTemplate(client, elasticsearchConverter);
+        return new OpenSearchTemplate(client, elasticsearchConverter, mappingParametersCustomizer);
     }
     // endregion
 
     // region child templates
     @Override
     public IndexOperations indexOps(Class<?> clazz) {
-        return new IndicesTemplate(client.indices(), getClusterTemplate(), elasticsearchConverter, clazz);
+        return new IndicesTemplate(client.indices(), getClusterTemplate(), elasticsearchConverter, mappingParametersCustomizer, clazz);
     }
 
     @Override
     public IndexOperations indexOps(IndexCoordinates index) {
-        return new IndicesTemplate(client.indices(), getClusterTemplate(), elasticsearchConverter, index);
+        return new IndicesTemplate(client.indices(), getClusterTemplate(), elasticsearchConverter, mappingParametersCustomizer, index);
     }
 
     @Override

--- a/spring-data-opensearch/src/main/java/org/opensearch/data/client/osc/RequestConverter.java
+++ b/spring-data-opensearch/src/main/java/org/opensearch/data/client/osc/RequestConverter.java
@@ -1839,8 +1839,9 @@ class RequestConverter {
         } else if (query instanceof StringQuery) {
             esQuery = Queries.wrapperQueryAsQuery(((StringQuery) query).getSource());
         } else if (query instanceof NativeQuery nativeQuery) {
-
-            if (nativeQuery.getQuery() != null) {
+            if (nativeQuery.getKnnQuery() != null) {
+                esQuery = nativeQuery.getKnnQuery().toQuery();
+            } else if (nativeQuery.getQuery() != null) {
                 esQuery = nativeQuery.getQuery();
             } else if (nativeQuery.getSpringDataQuery() != null) {
                 esQuery = getQuery(nativeQuery.getSpringDataQuery(), clazz);

--- a/spring-data-opensearch/src/main/java/org/opensearch/data/core/AbstractIndexTemplate.java
+++ b/spring-data-opensearch/src/main/java/org/opensearch/data/core/AbstractIndexTemplate.java
@@ -30,6 +30,7 @@ import org.springframework.data.elasticsearch.core.convert.ElasticsearchConverte
 import org.springframework.data.elasticsearch.core.document.Document;
 import org.springframework.data.elasticsearch.core.index.AliasData;
 import org.springframework.data.elasticsearch.core.index.MappingBuilder;
+import org.springframework.data.elasticsearch.core.index.MappingParametersCustomizer;
 import org.springframework.data.elasticsearch.core.index.Settings;
 import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentEntity;
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
@@ -46,6 +47,7 @@ import org.springframework.util.Assert;
 public abstract class AbstractIndexTemplate implements IndexOperations {
 
     protected final ElasticsearchConverter elasticsearchConverter;
+    protected final MappingParametersCustomizer mappingParametersCustomizer;
 
     @Nullable
     protected final Class<?> boundClass;
@@ -53,20 +55,22 @@ public abstract class AbstractIndexTemplate implements IndexOperations {
     @Nullable
     private final IndexCoordinates boundIndex;
 
-    public AbstractIndexTemplate(ElasticsearchConverter elasticsearchConverter, Class<?> boundClass) {
+    public AbstractIndexTemplate(ElasticsearchConverter elasticsearchConverter, MappingParametersCustomizer mappingParametersCustomizer, Class<?> boundClass) {
 
         Assert.notNull(boundClass, "boundClass may not be null");
 
         this.elasticsearchConverter = elasticsearchConverter;
+        this.mappingParametersCustomizer = mappingParametersCustomizer;
         this.boundClass = boundClass;
         this.boundIndex = null;
     }
 
-    public AbstractIndexTemplate(ElasticsearchConverter elasticsearchConverter, IndexCoordinates boundIndex) {
+    public AbstractIndexTemplate(ElasticsearchConverter elasticsearchConverter, MappingParametersCustomizer mappingParametersCustomizer, IndexCoordinates boundIndex) {
 
         Assert.notNull(boundIndex, "boundIndex may not be null");
 
         this.elasticsearchConverter = elasticsearchConverter;
+        this.mappingParametersCustomizer = mappingParametersCustomizer;
         this.boundClass = null;
         this.boundIndex = boundIndex;
     }
@@ -216,7 +220,7 @@ public abstract class AbstractIndexTemplate implements IndexOperations {
 
         // build mapping from field annotations
         try {
-            String mapping = new MappingBuilder(elasticsearchConverter).buildPropertyMapping(clazz);
+            String mapping = new MappingBuilder(elasticsearchConverter, mappingParametersCustomizer).buildPropertyMapping(clazz);
             return Document.parse(mapping);
         } catch (Exception e) {
             throw new UncategorizedElasticsearchException("Failed to build mapping for " + clazz.getSimpleName(), e);

--- a/spring-data-opensearch/src/main/java/org/opensearch/data/core/OpenSearchMappingParameters.java
+++ b/spring-data-opensearch/src/main/java/org/opensearch/data/core/OpenSearchMappingParameters.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.opensearch.data.core;
+
+import java.io.IOException;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldElementType;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.InnerField;
+import org.springframework.data.elasticsearch.annotations.KnnAlgorithmType;
+import org.springframework.data.elasticsearch.annotations.KnnSimilarity;
+import org.springframework.data.elasticsearch.core.index.MappingParameters;
+import tools.jackson.databind.node.ObjectNode;
+
+class OpenSearchMappingParameters extends MappingParameters {
+    static final String FIELD_PARAM_DIMENSION = "dimension";
+    static final String FIELD_PARAM_DATA_TYPE = "data_type";
+    static final String FIELD_PARAM_METHOD = "method";
+    static final String FIELD_PARAM_NAME = "name";
+    static final String FIELD_PARAM_M = "m";
+    static final String FIELD_PARAM_EF_CONSTRUCTION = "ef_construction";
+    static final String FIELD_PARAM_PARAMETERS = "parameters";
+    static final String FIELD_PARAM_SPACE_TYPE = "space_type";
+
+    protected OpenSearchMappingParameters(Field field) {
+        super(field);
+    }
+
+    protected OpenSearchMappingParameters(InnerField field) {
+        super(field);
+    }
+
+    @Override
+    public void writeTypeAndParametersTo(ObjectNode objectNode) throws IOException {
+        super.writeTypeAndParametersTo(objectNode);
+        if (type() == FieldType.Dense_Vector) {
+            // "dims" -> "dimension"
+            objectNode.remove("dims");
+            objectNode.put(FIELD_PARAM_DIMENSION, dims());
+
+            // "element_type" -> "data_type"
+            if (!FieldElementType.DEFAULT.equals(elementType())) {
+                objectNode.remove("element_type");
+                objectNode.put(FIELD_PARAM_DATA_TYPE, elementType());
+            }
+
+            // "similarity" -> "space_type"
+            if (knnSimilarity() != KnnSimilarity.DEFAULT) {
+                objectNode.remove("similarity");
+                objectNode.put(FIELD_PARAM_SPACE_TYPE, toSpaceType(knnSimilarity()));
+            }
+
+            // "index_options" -> "method"
+            if (knnIndexOptions() != null) {
+                objectNode.remove("index_options");
+                ObjectNode methodNode = objectNode.putObject(FIELD_PARAM_METHOD);
+                KnnAlgorithmType algoType = knnIndexOptions().type();
+                if (algoType != KnnAlgorithmType.DEFAULT) {
+                    methodNode.put(FIELD_PARAM_NAME, algoType.getType());
+                }
+
+                ObjectNode parametersNode = methodNode.putObject(FIELD_PARAM_PARAMETERS);
+                if (knnIndexOptions().m() >= 0) {
+                    parametersNode.put(FIELD_PARAM_M, knnIndexOptions().m());
+                }
+                if (knnIndexOptions().efConstruction() >= 0) {
+                    parametersNode.put(FIELD_PARAM_EF_CONSTRUCTION, knnIndexOptions().efConstruction());
+                }
+            }
+        }
+    }
+
+    private static String toSpaceType(KnnSimilarity similarity) {
+        switch (similarity) {
+            case COSINE: return "cosinesimil";
+            case L2_NORM: return "l2";
+            case DOT_PRODUCT: return "innerproduct";
+            case MAX_INNER_PRODUCT: return "innerproduct";
+            case DEFAULT: return null;
+        }
+        return "l2";
+    }
+}

--- a/spring-data-opensearch/src/main/java/org/opensearch/data/core/OpenSearchMappingParametersCustomizer.java
+++ b/spring-data-opensearch/src/main/java/org/opensearch/data/core/OpenSearchMappingParametersCustomizer.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.opensearch.data.core;
+
+import java.lang.annotation.Annotation;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.InnerField;
+import org.springframework.data.elasticsearch.core.index.MappingParameters;
+import org.springframework.data.elasticsearch.core.index.MappingParametersCustomizer;
+import org.springframework.util.Assert;
+
+public class OpenSearchMappingParametersCustomizer implements MappingParametersCustomizer {
+    @Override
+    public MappingParameters from(Annotation annotation) {
+        Assert.notNull(annotation, "annotation must not be null!");
+        if (annotation instanceof Field field) {
+            return new OpenSearchMappingParameters(field);
+        } else if (annotation instanceof InnerField innerField) {
+            return new OpenSearchMappingParameters(innerField);
+        } else {
+            throw new IllegalArgumentException("annotation must be an instance of @Field or @InnerField");
+        }
+    }
+}

--- a/spring-data-opensearch/src/test/java/org/opensearch/data/client/core/index/MappingBuilderORHLCIntegrationTests.java
+++ b/spring-data-opensearch/src/test/java/org/opensearch/data/client/core/index/MappingBuilderORHLCIntegrationTests.java
@@ -9,21 +9,13 @@
 
 package org.opensearch.data.client.core.index;
 
-import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.Disabled;
 import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.elasticsearch.annotations.Document;
-import org.springframework.data.elasticsearch.annotations.Dynamic;
-import org.springframework.data.elasticsearch.annotations.Field;
-import org.springframework.data.elasticsearch.annotations.FieldType;
-import org.springframework.data.elasticsearch.core.IndexOperations;
 import org.springframework.data.elasticsearch.core.index.MappingBuilderIntegrationTests;
 import org.springframework.data.elasticsearch.utils.IndexNameProvider;
-import org.springframework.lang.Nullable;
 import org.springframework.test.context.ContextConfiguration;
 
 @ContextConfiguration(classes = {MappingBuilderORHLCIntegrationTests.Config.class})
@@ -40,65 +32,13 @@ public class MappingBuilderORHLCIntegrationTests extends MappingBuilderIntegrati
 
     @Disabled
     @Override
-    public void shouldWriteDenseVectorFieldMapping() {
-        // see please https://github.com/opensearch-project/OpenSearch/pull/3659
+    public void shouldWriteWildcardFieldMapping() {
+        // Not supported by OpenSearch
     }
 
     @Disabled
     @Override
     public void shouldWriteRuntimeFields() {
         // Not supported by OpenSearch
-    }
-
-    @Disabled
-    @Override
-    public void shouldWriteWildcardFieldMapping() {
-        // Not supported by OpenSearch
-    }
-
-    @Override
-    public void shouldWriteDynamicMapping() {
-        IndexOperations indexOps = operations.indexOps(DynamicMappingEntity.class);
-        indexOps.createWithMapping();
-    }
-
-    @Document(indexName = "#{@indexNameProvider.indexName()}", dynamic = Dynamic.FALSE)
-    static class DynamicMappingEntity {
-
-        @Nullable
-        @Field(type = FieldType.Object) //
-        private Map<String, Object> objectInherit;
-
-        @Nullable
-        @Field(type = FieldType.Object, dynamic = Dynamic.FALSE) //
-        private Map<String, Object> objectFalse;
-
-        @Nullable
-        @Field(type = FieldType.Object, dynamic = Dynamic.STRICT) //
-        private Map<String, Object> objectStrict;
-
-        @Nullable
-        @Field(type = FieldType.Object, dynamic = Dynamic.RUNTIME) //
-        private Map<String, Object> objectRuntime;
-
-        @Nullable
-        @Field(type = FieldType.Nested) //
-        private List<Map<String, Object>> nestedObjectInherit;
-
-        @Nullable
-        @Field(type = FieldType.Nested, dynamic = Dynamic.FALSE) //
-        private List<Map<String, Object>> nestedObjectFalse;
-
-        @Nullable
-        @Field(type = FieldType.Nested, dynamic = Dynamic.TRUE) //
-        private List<Map<String, Object>> nestedObjectTrue;
-
-        @Nullable
-        @Field(type = FieldType.Nested, dynamic = Dynamic.STRICT) //
-        private List<Map<String, Object>> nestedObjectStrict;
-
-        @Nullable
-        @Field(type = FieldType.Nested, dynamic = Dynamic.RUNTIME) //
-        private List<Map<String, Object>> nestedObjectRuntime;
     }
 }

--- a/spring-data-opensearch/src/test/java/org/opensearch/data/client/core/index/MappingBuilderOSCIntegrationTests.java
+++ b/spring-data-opensearch/src/test/java/org/opensearch/data/client/core/index/MappingBuilderOSCIntegrationTests.java
@@ -9,21 +9,13 @@
 
 package org.opensearch.data.client.core.index;
 
-import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.Disabled;
 import org.opensearch.data.client.junit.jupiter.OpenSearchTemplateConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.elasticsearch.annotations.Document;
-import org.springframework.data.elasticsearch.annotations.Dynamic;
-import org.springframework.data.elasticsearch.annotations.Field;
-import org.springframework.data.elasticsearch.annotations.FieldType;
-import org.springframework.data.elasticsearch.core.IndexOperations;
 import org.springframework.data.elasticsearch.core.index.MappingBuilderIntegrationTests;
 import org.springframework.data.elasticsearch.utils.IndexNameProvider;
-import org.springframework.lang.Nullable;
 import org.springframework.test.context.ContextConfiguration;
 
 @ContextConfiguration(classes = {MappingBuilderOSCIntegrationTests.Config.class})
@@ -40,12 +32,6 @@ public class MappingBuilderOSCIntegrationTests extends MappingBuilderIntegration
 
     @Disabled
     @Override
-    public void shouldWriteDenseVectorFieldMapping() {
-        // see please https://github.com/opensearch-project/OpenSearch/pull/3659
-    }
-
-    @Disabled
-    @Override
     public void shouldWriteRuntimeFields() {
         // Not supported by OpenSearch
     }
@@ -54,51 +40,5 @@ public class MappingBuilderOSCIntegrationTests extends MappingBuilderIntegration
     @Override
     public void shouldWriteWildcardFieldMapping() {
         // Not supported by OpenSearch
-    }
-
-    @Override
-    public void shouldWriteDynamicMapping() {
-        IndexOperations indexOps = operations.indexOps(DynamicMappingEntity.class);
-        indexOps.createWithMapping();
-    }
-
-    @Document(indexName = "#{@indexNameProvider.indexName()}", dynamic = Dynamic.FALSE)
-    static class DynamicMappingEntity {
-
-        @Nullable
-        @Field(type = FieldType.Object) //
-        private Map<String, Object> objectInherit;
-
-        @Nullable
-        @Field(type = FieldType.Object, dynamic = Dynamic.FALSE) //
-        private Map<String, Object> objectFalse;
-
-        @Nullable
-        @Field(type = FieldType.Object, dynamic = Dynamic.STRICT) //
-        private Map<String, Object> objectStrict;
-
-        @Nullable
-        @Field(type = FieldType.Object, dynamic = Dynamic.RUNTIME) //
-        private Map<String, Object> objectRuntime;
-
-        @Nullable
-        @Field(type = FieldType.Nested) //
-        private List<Map<String, Object>> nestedObjectInherit;
-
-        @Nullable
-        @Field(type = FieldType.Nested, dynamic = Dynamic.FALSE) //
-        private List<Map<String, Object>> nestedObjectFalse;
-
-        @Nullable
-        @Field(type = FieldType.Nested, dynamic = Dynamic.TRUE) //
-        private List<Map<String, Object>> nestedObjectTrue;
-
-        @Nullable
-        @Field(type = FieldType.Nested, dynamic = Dynamic.STRICT) //
-        private List<Map<String, Object>> nestedObjectStrict;
-
-        @Nullable
-        @Field(type = FieldType.Nested, dynamic = Dynamic.RUNTIME) //
-        private List<Map<String, Object>> nestedObjectRuntime;
     }
 }

--- a/spring-data-opensearch/src/test/java/org/opensearch/data/client/junit/jupiter/OpenSearchRestTemplateConfiguration.java
+++ b/spring-data-opensearch/src/test/java/org/opensearch/data/client/junit/jupiter/OpenSearchRestTemplateConfiguration.java
@@ -24,6 +24,7 @@ import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.RefreshPolicy;
 import org.springframework.data.elasticsearch.core.convert.ElasticsearchConverter;
+import org.springframework.data.elasticsearch.core.index.MappingParametersCustomizer;
 import org.springframework.data.elasticsearch.junit.jupiter.ClusterConnectionInfo;
 
 /**
@@ -72,9 +73,9 @@ public class OpenSearchRestTemplateConfiguration extends AbstractOpenSearchConfi
 
     @Override
     public ElasticsearchOperations elasticsearchOperations(
-            ElasticsearchConverter elasticsearchConverter, RestHighLevelClient elasticsearchClient) {
+            ElasticsearchConverter elasticsearchConverter, RestHighLevelClient elasticsearchClient, MappingParametersCustomizer opensearchMappingParametersCustomizer) {
 
-        OpenSearchRestTemplate template = new OpenSearchRestTemplate(elasticsearchClient, elasticsearchConverter) {
+        OpenSearchRestTemplate template = new OpenSearchRestTemplate(elasticsearchClient, elasticsearchConverter, opensearchMappingParametersCustomizer) {
             @Override
             public <T> T execute(ClientCallback<T> callback) {
                 try {

--- a/spring-data-opensearch/src/test/java/org/opensearch/data/client/repositories/knn/KnnSearchORHLIntegrationTests.java
+++ b/spring-data-opensearch/src/test/java/org/opensearch/data/client/repositories/knn/KnnSearchORHLIntegrationTests.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opensearch.data.client.repositories.knn;
+
+import java.util.List;
+import org.opensearch.data.client.junit.jupiter.OpenSearchRestTemplateConfiguration;
+import org.opensearch.data.client.orhlc.NativeSearchQueryBuilder;
+import org.opensearch.data.client.orhlc.knn.KnnQueryBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.core.query.Query;
+import org.springframework.data.elasticsearch.repositories.knn.KnnSearchIntegrationTests;
+import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
+import org.springframework.data.elasticsearch.utils.IndexNameProvider;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * @author Haibo Liu
+ * @since 5.4
+ */
+@ContextConfiguration(classes = { KnnSearchORHLIntegrationTests.Config.class })
+public class KnnSearchORHLIntegrationTests extends KnnSearchIntegrationTests {
+
+    @Configuration
+    @Import({ OpenSearchRestTemplateConfiguration.class })
+    @EnableElasticsearchRepositories(
+            basePackages = { "org.springframework.data.elasticsearch.repositories.knn" },
+            considerNestedRepositories = true)
+    static class Config {
+        @Bean
+        IndexNameProvider indexNameProvider() {
+            return new IndexNameProvider("knn-repository-os");
+        }
+    }
+
+    @Override
+    protected Query getQuery(List<Float> vector) {
+         return new NativeSearchQueryBuilder()
+                .withQuery(KnnQueryBuilder.builder().vector(vector).k(3).field("vector").build())
+                .withPageable(Pageable.ofSize(2))
+                .build();
+    }
+}

--- a/spring-data-opensearch/src/test/java/org/opensearch/data/client/repositories/knn/KnnSearchOSCIntegrationTests.java
+++ b/spring-data-opensearch/src/test/java/org/opensearch/data/client/repositories/knn/KnnSearchOSCIntegrationTests.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opensearch.data.client.repositories.knn;
+
+import java.util.List;
+import org.opensearch.data.client.junit.jupiter.OpenSearchTemplateConfiguration;
+import org.opensearch.data.client.osc.NativeQueryBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.core.query.Query;
+import org.springframework.data.elasticsearch.repositories.knn.KnnSearchIntegrationTests;
+import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
+import org.springframework.data.elasticsearch.utils.IndexNameProvider;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * @author Haibo Liu
+ * @since 5.4
+ */
+@ContextConfiguration(classes = { KnnSearchOSCIntegrationTests.Config.class })
+public class KnnSearchOSCIntegrationTests extends KnnSearchIntegrationTests {
+
+    @Configuration
+    @Import({ OpenSearchTemplateConfiguration.class })
+    @EnableElasticsearchRepositories(
+            basePackages = { "org.springframework.data.elasticsearch.repositories.knn" },
+            considerNestedRepositories = true)
+    static class Config {
+        @Bean
+        IndexNameProvider indexNameProvider() {
+            return new IndexNameProvider("knn-repository-os");
+        }
+    }
+
+    @Override
+    protected Query getQuery(List<Float> vector) {
+        return  new NativeQueryBuilder()
+                .withKnnQuery(ksb -> ksb.vector(vector).k(3).field("vector"))
+                .withPageable(Pageable.ofSize(2))
+                .build();
+
+
+    }
+}

--- a/spring-data-opensearch/src/test/java/org/springframework/data/elasticsearch/core/MappingContextBaseTests.java
+++ b/spring-data-opensearch/src/test/java/org/springframework/data/elasticsearch/core/MappingContextBaseTests.java
@@ -15,6 +15,7 @@
 
 package org.springframework.data.elasticsearch.core;
 
+import org.opensearch.data.core.OpenSearchMappingParametersCustomizer;
 import org.springframework.data.elasticsearch.config.ElasticsearchConfigurationSupport;
 import org.springframework.data.elasticsearch.core.convert.ElasticsearchConverter;
 import org.springframework.data.elasticsearch.core.convert.MappingElasticsearchConverter;
@@ -43,6 +44,6 @@ public abstract class MappingContextBaseTests {
 	}
 
 	final protected MappingBuilder getMappingBuilder() {
-		return new MappingBuilder(elasticsearchConverter.get());
+		return new MappingBuilder(elasticsearchConverter.get(), new OpenSearchMappingParametersCustomizer());
 	}
 }

--- a/spring-data-opensearch/src/test/java/org/springframework/data/elasticsearch/core/index/MappingBuilderIntegrationTests.java
+++ b/spring-data-opensearch/src/test/java/org/springframework/data/elasticsearch/core/index/MappingBuilderIntegrationTests.java
@@ -173,7 +173,7 @@ public abstract class MappingBuilderIntegrationTests extends MappingContextBaseT
 
 	@Test // DATAES-991
 	@DisplayName("should write correct TermVector values")
-	public void shouldWriteCorrectTermVectorValues() {
+	void shouldWriteCorrectTermVectorValues() {
 
 		IndexOperations indexOps = operations.indexOps(TermVectorFieldEntity.class);
 		indexOps.createWithMapping();
@@ -189,7 +189,7 @@ public abstract class MappingBuilderIntegrationTests extends MappingContextBaseT
 
 	@Test // #1700
 	@DisplayName("should write dense_vector field mapping")
-	public void shouldWriteDenseVectorFieldMapping() {
+	void shouldWriteDenseVectorFieldMapping() {
 
 		IndexOperations indexOps = operations.indexOps(DenseVectorEntity.class);
 		indexOps.createWithMapping();
@@ -197,7 +197,7 @@ public abstract class MappingBuilderIntegrationTests extends MappingContextBaseT
 
 	@Test // #1370
 	@DisplayName("should write mapping for disabled entity")
-	public void shouldWriteMappingForDisabledEntity() {
+	void shouldWriteMappingForDisabledEntity() {
 
 		IndexOperations indexOps = operations.indexOps(DisabledMappingEntity.class);
 		indexOps.createWithMapping();
@@ -205,7 +205,7 @@ public abstract class MappingBuilderIntegrationTests extends MappingContextBaseT
 
 	@Test // #1370
 	@DisplayName("should write mapping for disabled property")
-	public void shouldWriteMappingForDisabledProperty() {
+	void shouldWriteMappingForDisabledProperty() {
 
 		IndexOperations indexOps = operations.indexOps(DisabledMappingProperty.class);
 		indexOps.createWithMapping();
@@ -213,15 +213,41 @@ public abstract class MappingBuilderIntegrationTests extends MappingContextBaseT
 
 	@Test // #1767
 	@DisplayName("should write dynamic mapping annotations")
-	public void shouldWriteDynamicMappingAnnotations() {
+	void shouldWriteDynamicMappingAnnotations() {
 
 		IndexOperations indexOps = operations.indexOps(DynamicMappingAnnotationEntity.class);
 		indexOps.createWithMapping();
+		
+		var mapping = indexOps.getMapping();
+        var dynamic = mapping.get("dynamic");
+        if (dynamic instanceof String s) {
+            assertThat(dynamic).isEqualTo("false");
+        } else {
+            assertThat(mapping.get("dynamic")).isEqualTo(false);
+        }
 	}
+	
+	@Test // #2478
+    @DisplayName("should write dynamic mapping annotations on put")
+	void shouldWriteDynamicMappingAnnotationsOnPut() {
+
+        IndexOperations indexOps = operations.indexOps(DynamicMappingAnnotationEntity.class);
+        indexOps.create();
+
+        indexOps.putMapping();
+
+        var mapping = indexOps.getMapping();
+        var dynamic = mapping.get("dynamic");
+        if (dynamic instanceof String s) {
+            assertThat(dynamic).isEqualTo("false");
+        } else {
+            assertThat(mapping.get("dynamic")).isEqualTo(false);
+        }
+    }
 
 	@Test // #1871
 	@DisplayName("should write dynamic mapping")
-	public void shouldWriteDynamicMapping() {
+	void shouldWriteDynamicMapping() {
 
 		IndexOperations indexOps = operations.indexOps(DynamicMappingEntity.class);
 		indexOps.createWithMapping();
@@ -229,7 +255,7 @@ public abstract class MappingBuilderIntegrationTests extends MappingContextBaseT
 
 	@Test // #638
 	@DisplayName("should write dynamic detection values")
-	public void shouldWriteDynamicDetectionValues() {
+	void shouldWriteDynamicDetectionValues() {
 
 		IndexOperations indexOps = operations.indexOps(DynamicDetectionMapping.class);
 		indexOps.createWithMapping();
@@ -239,16 +265,36 @@ public abstract class MappingBuilderIntegrationTests extends MappingContextBaseT
 	@DisplayName("should write runtime fields")
 	public void shouldWriteRuntimeFields() {
 
-		IndexOperations indexOps = operations.indexOps(RuntimeFieldEntity.class);
+		IndexOperations indexOps = operations.indexOps(DerivedFieldEntity.class);
 		indexOps.createWithMapping();
 	}
 
 	@Test // #796
 	@DisplayName("should write source excludes")
-	public void shouldWriteSourceExcludes() {
+	void shouldWriteSourceExcludes() {
 
 		IndexOperations indexOps = operations.indexOps(ExcludedFieldEntity.class);
 		indexOps.createWithMapping();
+	}
+
+	@Test // #2502
+	@DisplayName(" should write mapping with field name with dots")
+	void shouldWriteMappingWithFieldNameWithDots() {
+
+		IndexOperations indexOps = operations.indexOps(FieldNameDotsEntity.class);
+		indexOps.createWithMapping();
+	}
+
+	@Test // #2659
+	@DisplayName("should write correct mapping for dense vector property")
+	void shouldWriteCorrectMappingForDenseVectorProperty() {
+		operations.indexOps(SimilarityEntity.class).createWithMapping();
+	}
+
+	@Test // #2845
+	@DisplayName("should write mapping with field aliases")
+	void shouldWriteMappingWithFieldAliases() {
+		operations.indexOps(FieldAliasEntity.class).createWithMapping();
 	}
 
 	// region Entities
@@ -697,7 +743,7 @@ public abstract class MappingBuilderIntegrationTests extends MappingContextBaseT
 		@Nullable
 		@Id private String id;
 		@Nullable
-		@Field(type = Dense_Vector, dims = 3) private float[] dense_vector;
+		@Field(type = Dense_Vector, dims = 3, mappedTypeName = "knn_vector") private float[] dense_vector;
 
 		@Nullable
 		public String getId() {
@@ -754,9 +800,6 @@ public abstract class MappingBuilderIntegrationTests extends MappingContextBaseT
 		@Field(type = FieldType.Object, dynamic = Dynamic.STRICT) //
 		private Map<String, Object> objectStrict;
 		@Nullable
-		@Field(type = FieldType.Object, dynamic = Dynamic.RUNTIME) //
-		private Map<String, Object> objectRuntime;
-		@Nullable
 		@Field(type = FieldType.Nested) //
 		private List<Map<String, Object>> nestedObjectInherit;
 		@Nullable
@@ -768,9 +811,6 @@ public abstract class MappingBuilderIntegrationTests extends MappingContextBaseT
 		@Nullable
 		@Field(type = FieldType.Nested, dynamic = Dynamic.STRICT) //
 		private List<Map<String, Object>> nestedObjectStrict;
-		@Nullable
-		@Field(type = FieldType.Nested, dynamic = Dynamic.RUNTIME) //
-		private List<Map<String, Object>> nestedObjectRuntime;
 	}
 
 	@Document(indexName = "#{@indexNameProvider.indexName()}")
@@ -782,8 +822,8 @@ public abstract class MappingBuilderIntegrationTests extends MappingContextBaseT
 	}
 
 	@Document(indexName = "#{@indexNameProvider.indexName()}")
-	@Mapping(runtimeFieldsPath = "/mappings/runtime-fields.json")
-	private static class RuntimeFieldEntity {
+	@Mapping(runtimeFieldsPath = "/mappings/derived-fields.json")
+	private static class DerivedFieldEntity {
 		@Id
 		@Nullable private String id;
 		@Field(type = Date, format = DateFormat.epoch_millis, name = "@timestamp")
@@ -870,6 +910,40 @@ public abstract class MappingBuilderIntegrationTests extends MappingContextBaseT
 		@Field(type = FieldType.Rank_Features) String rankFeaturesField;
 		@Nullable
 		@Field(type = FieldType.Wildcard) String wildcardField;
+	    @Nullable
+	    @Field(type = FieldType.Dense_Vector, dims = 1, mappedTypeName = "knn_vector") String denseVectorField;
+
 	}
+	
+	@Document(indexName = "#{@indexNameProvider.indexName()}")
+    private static class FieldNameDotsEntity {
+        @Id
+        @Nullable private String id;
+        @Nullable
+        @Field(name = "dotted.field", type = Text) private String dottedField;
+    }
+
+    @Document(indexName = "#{@indexNameProvider.indexName()}")
+    static class SimilarityEntity {
+        @Nullable
+        @Id private String id;
+
+        @Field(type = FieldType.Dense_Vector, dims = 42, mappedTypeName = "knn_vector",
+                knnSimilarity = KnnSimilarity.COSINE) private double[] denseVector;
+    }
+
+    @Mapping(aliases = {
+            @MappingAlias(name = "someAlly", path = "someText"),
+            @MappingAlias(name = "otherAlly", path = "otherText")
+    })
+    @Document(indexName = "#{@indexNameProvider.indexName()}")
+    private static class FieldAliasEntity {
+        @Id
+        @Nullable private String id;
+        @Nullable
+        @Field(type = Text) private String someText;
+        @Nullable
+        @Field(type = Text) private String otherText;
+    }
 	// endregion
 }

--- a/spring-data-opensearch/src/test/java/org/springframework/data/elasticsearch/core/index/MappingBuilderUnitTests.java
+++ b/spring-data-opensearch/src/test/java/org/springframework/data/elasticsearch/core/index/MappingBuilderUnitTests.java
@@ -1,0 +1,2623 @@
+/*
+ * Copyright 2013-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.elasticsearch.core.index;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.skyscreamer.jsonassert.JSONAssert.*;
+import static org.springframework.data.elasticsearch.annotations.FieldType.*;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.json.JSONException;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.Transient;
+import org.springframework.data.domain.Range;
+import org.springframework.data.elasticsearch.annotations.*;
+import org.springframework.data.elasticsearch.core.MappingContextBaseTests;
+import org.springframework.data.elasticsearch.core.geo.GeoPoint;
+import org.springframework.data.elasticsearch.core.mapping.SimpleElasticsearchMappingContext;
+import org.springframework.data.elasticsearch.core.query.SeqNoPrimaryTerm;
+import org.springframework.data.elasticsearch.core.suggest.Completion;
+import org.springframework.data.geo.Box;
+import org.springframework.data.geo.Circle;
+import org.springframework.data.geo.Point;
+import org.springframework.data.geo.Polygon;
+import org.springframework.data.mapping.MappingException;
+
+/**
+ * @author Stuart Stevenson
+ * @author Jakub Vavrik
+ * @author Mohsin Husen
+ * @author Keivn Leturc
+ * @author Nordine Bittich
+ * @author Don Wellington
+ * @author Sascha Woo
+ * @author Peter-Josef Meisch
+ * @author Xiao Yu
+ * @author Roman Puchkovskiy
+ * @author Brian Kimmig
+ * @author Morgan Lutz
+ * @author Haibo Liu
+ * @author Andriy Redko
+ */
+public class MappingBuilderUnitTests extends MappingContextBaseTests {
+
+	@Test // DATAES-568
+	public void testInfiniteLoopAvoidance() throws JSONException {
+
+		String expected = """
+				{
+						"properties": {
+							"message": {
+								"store": true,
+								"type": "text",
+								"index": false,
+								"analyzer": "standard"
+							}
+						}
+					}
+				""";
+
+		String mapping = getMappingBuilder().buildPropertyMapping(SampleTransientEntity.class);
+
+		assertEquals(expected, mapping, false);
+	}
+
+	@Test // DATAES-568
+	public void shouldUseValueFromAnnotationType() throws JSONException {
+
+		String expected = """
+				  {
+				  "properties": {
+				    "price": {
+				      "type": "double"
+				    }
+				  }
+				}
+				""";
+
+		String mapping = getMappingBuilder().buildPropertyMapping(StockPrice.class);
+
+		assertEquals(expected, mapping, false);
+	}
+
+	@Test // DATAES-76
+	public void shouldBuildMappingWithSuperclass() throws JSONException {
+
+		String expected = """
+				{
+						"properties": {
+							"message": {
+								"store": true,
+								"type": "text",
+								"index": false,
+								"analyzer": "standard"
+							},
+							"createdDate": {
+								"type": "date",
+								"index": false
+							}
+						}
+					}
+				""";
+
+		String mapping = getMappingBuilder().buildPropertyMapping(SampleInheritedEntity.class);
+
+		assertEquals(expected, mapping, false);
+	}
+
+	@Test // DATAES-285
+	public void shouldMapBooks() throws JSONException {
+
+		String expected = """
+				{
+				  "properties": {
+				    "author": {
+				      "type": "object",
+				      "properties": {}
+				    },
+				    "buckets": {
+				      "type": "nested"
+				    },
+				    "description": {
+				      "type": "text",
+				      "analyzer": "whitespace",
+				      "fields": {
+				        "prefix": {
+				          "type": "text",
+				          "analyzer": "stop",
+				          "search_analyzer": "standard"
+				        }
+				      }
+				    }
+				  }
+				}"""; //
+
+		String mapping = getMappingBuilder().buildPropertyMapping(Book.class);
+
+		assertEquals(expected, mapping, false);
+	}
+
+	@Test // DATAES-568, DATAES-929
+	@DisplayName("should build mappings for geo types")
+	void shouldBuildMappingsForGeoTypes() throws JSONException {
+
+		String expected = """
+				{
+				  "properties": {
+				    "pointA": {
+				      "type": "geo_point"
+				    },
+				    "pointB": {
+				      "type": "geo_point"
+				    },
+				    "pointC": {
+				      "type": "geo_point"
+				    },
+				    "pointD": {
+				      "type": "geo_point"
+				    },
+				    "shape1": {
+				      "type": "geo_shape"
+				    },
+				    "shape2": {
+				      "type": "geo_shape",
+				      "orientation": "clockwise",
+				      "ignore_malformed": true,
+				      "ignore_z_value": false,
+				      "coerce": true
+				    }
+				  }
+				}
+				"""; //
+
+		String mapping;
+		mapping = getMappingBuilder().buildPropertyMapping(GeoEntity.class);
+
+		assertEquals(expected, mapping, false);
+	}
+
+	@Test // DATAES-568
+	public void shouldUseFieldNameOnId() throws JSONException {
+
+		String expected = """
+				{
+				  "properties": {
+				    "id-property": {
+				      "type": "keyword",
+				      "index": true
+				    }
+				  }
+				}
+				""";
+
+		String mapping = getMappingBuilder().buildPropertyMapping(FieldNameEntity.IdEntity.class);
+
+		assertEquals(expected, mapping, false);
+	}
+
+	@Test // DATAES-568
+	public void shouldUseFieldNameOnText() throws JSONException {
+
+		String expected = """
+						{
+					"properties": {
+						"id-property": {
+							"type": "keyword",
+							"index": true
+						},
+						"text-property": {
+							"type": "text"
+						}
+					}
+				}
+				""";
+
+		String mapping = getMappingBuilder().buildPropertyMapping(FieldNameEntity.TextEntity.class);
+
+		assertEquals(expected, mapping, false);
+	}
+
+	@Test // DATAES-568
+	public void shouldUseFieldNameOnMapping() throws JSONException {
+
+		String expected = """
+					{
+					"properties": {
+						"id-property": {
+							"type": "keyword",
+							"index": true
+						},
+						"mapping-property": {
+							"type": "string",
+							"analyzer": "standard_lowercase_asciifolding"
+						}
+					}
+				}
+				""";
+
+		String mapping = getMappingBuilder().buildPropertyMapping(FieldNameEntity.MappingEntity.class);
+
+		assertEquals(expected, mapping, false);
+	}
+
+	@Test // DATAES-568
+	public void shouldUseFieldNameOnGeoPoint() throws JSONException {
+
+		String expected = """
+				{
+					"properties": {
+						"id-property": {
+							"type": "keyword",
+							"index": true
+						},
+						"geopoint-property": {
+							"type": "geo_point"
+						}
+					}
+				}
+				""";
+
+		String mapping = getMappingBuilder().buildPropertyMapping(FieldNameEntity.GeoPointEntity.class);
+
+		assertEquals(expected, mapping, false);
+	}
+
+	@Test // DATAES-568
+	public void shouldUseFieldNameOnCircularEntity() throws JSONException {
+
+		String expected = """
+					{
+					"properties": {
+						"id-property": {
+							"type": "keyword",
+							"index": true
+						},
+						"circular-property": {
+							"type": "object",
+							"properties": {}
+						}
+					}
+				}
+				""";
+
+		String mapping = getMappingBuilder().buildPropertyMapping(FieldNameEntity.CircularEntity.class);
+
+		assertEquals(expected, mapping, false);
+	}
+
+	@Test // DATAES-568
+	public void shouldUseFieldNameOnCompletion() throws JSONException {
+
+		String expected = """
+				{
+					"properties": {
+						"id-property": {
+							"type": "keyword",
+							"index": true
+						},
+						"completion-property": {
+							"type": "completion",
+							"max_input_length": 100,
+							"preserve_position_increments": true,
+							"preserve_separators": true,
+							"search_analyzer": "simple",
+							"analyzer": "simple"
+						}
+					}
+				}
+				""";
+
+		String mapping = getMappingBuilder().buildPropertyMapping(FieldNameEntity.CompletionEntity.class);
+
+		assertEquals(expected, mapping, false);
+	}
+
+	@Test // DATAES-568, DATAES-896
+	public void shouldUseFieldNameOnMultiField() throws JSONException {
+
+		String expected = """
+				{
+				  "properties": {
+				    "id-property": {
+				      "type": "keyword",
+				      "index": true
+				    },
+				    "main-field": {
+				      "type": "text",
+				      "analyzer": "whitespace",
+				      "fields": {
+				        "suff-ix": {
+				          "type": "text",
+				          "analyzer": "stop",
+				          "search_analyzer": "standard"
+				        }
+				      }
+				    },
+				    "alternate-description": {
+				      "type": "text",
+				      "analyzer": "whitespace",
+				      "fields": {
+				        "suff-ix": {
+				          "type": "text",
+				          "analyzer": "stop",
+				          "search_analyzer": "standard"
+				        }
+				      }
+				    }
+				  }
+				}
+				"""; //
+
+		String mapping = getMappingBuilder().buildPropertyMapping(FieldNameEntity.MultiFieldEntity.class);
+
+		assertEquals(expected, mapping, false);
+	}
+
+	@Test // DATAES-639
+	public void shouldUseIgnoreAbove() throws JSONException {
+
+		String expected = """
+				{
+					"properties": {
+						"message": {
+							"type": "keyword",
+							"ignore_above": 10
+						}
+					}
+				}
+				""";
+
+		String mapping = getMappingBuilder().buildPropertyMapping(IgnoreAboveEntity.class);
+
+		assertEquals(expected, mapping, false);
+	}
+
+	@Test // DATAES-621, DATAES-943, DATAES-946
+	public void shouldSetFieldMappingProperties() throws JSONException {
+		String expected = """
+				{
+				        "properties": {
+				            "storeTrue": {
+				                "store": true
+				            },
+				            "indexFalse": {
+				                "index": false
+				            },
+				            "coerceFalse": {
+				                "coerce": false
+				            },
+				            "fielddataTrue": {
+				                "fielddata": true
+				            },
+				            "type": {
+				                "type": "integer"
+				            },
+				            "ignoreAbove": {
+				                "ignore_above": 42
+				            },
+				            "copyTo": {
+				                "copy_to": ["foo", "bar"]
+				            },
+				            "date": {
+				                "type": "date",
+				                "format": "YYYYMMDD"
+				            },
+				            "analyzers": {
+				                "analyzer": "ana",
+				                "search_analyzer": "sana",
+				                "normalizer": "norma"
+				            },
+				            "docValuesTrue": {
+				                "type": "keyword"
+				            },
+				            "docValuesFalse": {
+				                "type": "keyword",
+				                "doc_values": false
+				            },
+				            "ignoreMalformedTrue": {
+				                "ignore_malformed": true
+				            },
+				            "indexPhrasesTrue": {
+				                "index_phrases": true
+				            },
+				            "indexOptionsPositions": {
+				                "index_options": "positions"
+				            },
+				            "defaultIndexPrefixes": {
+				                "index_prefixes":{}            },
+				            "customIndexPrefixes": {
+				                "index_prefixes":{"min_chars":1,"max_chars":10}            },
+				            "normsFalse": {
+				                "norms": false
+				            },
+				            "nullValueString": {
+				                "null_value": "NULLNULL"
+				            },
+				            "nullValueInteger": {
+				                "null_value": 42
+				            },
+				            "nullValueDouble": {
+				                "null_value": 42.0
+				            },
+				            "positionIncrementGap": {
+				                "position_increment_gap": 42
+				            },
+				            "similarityBoolean": {
+				                "similarity": "boolean"
+				            },
+				            "termVectorWithOffsets": {
+				                "term_vector": "with_offsets"
+				            },
+				            "scaledFloat": {
+				                "type": "scaled_float",
+				                "scaling_factor": 100.0
+				            },
+				            "enabledObject": {
+				                "type": "object"
+				            },
+				            "disabledObject": {
+				                "type": "object",
+				                "enabled": false
+				            },
+				            "eagerGlobalOrdinalsTrue": {
+				                "type": "text",
+				                "eager_global_ordinals": true
+				            },
+				            "eagerGlobalOrdinalsFalse": {
+				                "type": "text"
+				            },
+				            "wildcardWithoutParams": {
+				                "type": "wildcard"
+				            },
+				            "wildcardWithParams": {
+				                "type": "wildcard",
+				                "null_value": "WILD",
+				                "ignore_above": 42
+				            }
+				        }
+				}
+				""";
+
+		String mapping = getMappingBuilder().buildPropertyMapping(FieldMappingParameters.class);
+
+		assertEquals(expected, mapping, false);
+	}
+
+	@Test // DATAES-148, #1767
+	void shouldWriteDynamicMappingFromAnnotation() throws JSONException {
+
+		String expected = """
+				{
+				  "dynamic": "false",
+				  "properties": {
+				    "_class": {
+				      "type": "keyword",
+				      "index": false,
+				      "doc_values": false
+				    },
+				    "author": {
+				      "type": "object",
+				      "dynamic": "strict",
+				      "properties": {
+				        "_class": {
+				          "type": "keyword",
+				          "index": false,
+				          "doc_values": false
+				        }
+				      }
+				    },
+				    "objectMap": {
+				      "type": "object",
+				      "dynamic": "false"
+				    },
+				    "nestedObjectMap": {
+				      "type": "nested",
+				      "dynamic": "false"
+				    }
+				  }
+				}"""; //
+
+		String mapping = getMappingBuilder().buildPropertyMapping(DynamicMappingAnnotationEntity.class);
+
+		assertEquals(expected, mapping, true);
+	}
+
+	@Test // #1871
+	void shouldWriteDynamicMapping() throws JSONException {
+
+		String expected = """
+				{
+				  "dynamic": "false",
+				  "properties": {
+				    "_class": {
+				      "type": "keyword",
+				      "index": false,
+				      "doc_values": false
+				    },
+				    "objectInherit": {
+				      "type": "object"
+				    },
+				    "objectFalse": {
+				      "dynamic": "false",
+				      "type": "object"
+				    },
+				    "objectTrue": {
+				      "dynamic": "true",
+				      "type": "object"
+				    },
+				    "objectStrict": {
+				      "dynamic": "strict",
+				      "type": "object"
+				    },
+				    "objectRuntime": {
+				      "dynamic": "runtime",
+				      "type": "object"
+				    },
+				    "nestedObjectInherit": {
+				      "type": "nested"
+				    },
+				    "nestedObjectFalse": {
+				      "dynamic": "false",
+				      "type": "nested"
+				    },
+				    "nestedObjectTrue": {
+				      "dynamic": "true",
+				      "type": "nested"
+				    },
+				    "nestedObjectStrict": {
+				      "dynamic": "strict",
+				      "type": "nested"
+				    },
+				    "nestedObjectRuntime": {
+				      "dynamic": "runtime",
+				      "type": "nested"
+				    }
+				  }
+				}
+				""";
+
+		String mapping = getMappingBuilder().buildPropertyMapping(DynamicMappingEntity.class);
+
+		assertEquals(expected, mapping, true);
+	}
+
+	@Test // DATAES-784
+	void shouldMapPropertyObjectsToFieldDefinition() throws JSONException {
+		String expected = """
+				{
+				  properties: {
+				    valueObject: {
+				      type: "text"
+				    }
+				  }
+				}""";
+
+		String mapping = getMappingBuilder().buildPropertyMapping(ValueDoc.class);
+
+		assertEquals(expected, mapping, false);
+	}
+
+	@Test // DATAES-788
+	void shouldWriteCompletionContextInfo() throws JSONException {
+		String expected = """
+				{
+				  "properties": {
+				    "suggest": {
+				      "type": "completion",
+				      "contexts": [
+				        {
+				          "name": "location",
+				          "type": "geo",
+				          "path": "proppath"
+				        }
+				      ]
+				    }
+				  }
+				}""";
+
+		String mapping = getMappingBuilder().buildPropertyMapping(CompletionDocument.class);
+
+		assertEquals(expected, mapping, false);
+	}
+
+	@Test // DATAES-799
+	void shouldNotIncludeSeqNoPrimaryTermPropertyInMappingEvenWhenAnnotatedWithField() {
+		String propertyMapping = getMappingBuilder().buildPropertyMapping(EntityWithSeqNoPrimaryTerm.class);
+
+		assertThat(propertyMapping).doesNotContain("seqNoPrimaryTerm");
+	}
+
+	@Test // DATAES-854
+	@DisplayName("should write rank_feature properties")
+	void shouldWriteRankFeatureProperties() throws JSONException {
+		String expected = """
+				{
+				  "properties": {
+				    "pageRank": {
+				      "type": "rank_feature"
+				    },
+				    "urlLength": {
+				      "type": "rank_feature",
+				      "positive_score_impact": false
+				    },
+				    "topics": {
+				      "type": "rank_features"
+				    }
+				  }
+				}
+				"""; //
+
+		String mapping = getMappingBuilder().buildPropertyMapping(RankFeatureEntity.class);
+
+		assertEquals(expected, mapping, false);
+	}
+
+	@Test // #1700
+	@DisplayName("should write knn_vector properties")
+	void shouldWriteDenseVectorProperties() throws JSONException {
+		String expected = """
+				{
+				  "properties": {
+				    "my_vector": {
+				      "type": "knn_vector",
+				      "dimension": 16
+				    }
+				  }
+				}
+				"""; //
+
+		String mapping = getMappingBuilder().buildPropertyMapping(DenseVectorEntity.class);
+
+		assertEquals(expected, mapping, false);
+	}
+
+	@Test
+	@DisplayName("should write dense_vector properties for knn search")
+	void shouldWriteDenseVectorPropertiesWithKnnSearch() throws JSONException {
+		String expected = """
+				{
+				  "properties":{
+				    "my_vector":{
+				      "type":"knn_vector",
+				      "dimension":16,
+				      "data_type":"float",
+				      "space_type":"innerproduct",
+				      "method":{
+				        "name":"hnsw",
+				        "parameters": {
+				            "m":16,
+				            "ef_construction":100
+				        }
+				      }
+				    }
+				  }
+				}
+				""";
+
+		String mapping = getMappingBuilder().buildPropertyMapping(DenseVectorEntityWithKnnSearch.class);
+
+		assertEquals(expected, mapping, false);
+	}
+
+	@Test // #1370
+	@DisplayName("should not write mapping when enabled is false on entity")
+	void shouldNotWriteMappingWhenEnabledIsFalseOnEntity() throws JSONException {
+
+		String expected = """
+				{
+					"enabled": false
+				}
+				""";
+
+		String mapping = getMappingBuilder().buildPropertyMapping(DisabledMappingEntity.class);
+
+		assertEquals(expected, mapping, false);
+	}
+
+	@Test // #1370
+	@DisplayName("should write disabled property mapping")
+	void shouldWriteDisabledPropertyMapping() throws JSONException {
+
+		String expected = """
+				{
+				  "properties":{
+				    "text": {
+				      "type": "text"
+				    },
+				    "object": {
+				      "type": "object",
+				      "enabled": false
+				    }
+				  }
+				}
+				"""; //
+
+		String mapping = getMappingBuilder().buildPropertyMapping(DisabledMappingProperty.class);
+
+		assertEquals(expected, mapping, false);
+	}
+
+	@Test // #1370
+	@DisplayName("should only allow disabled properties on type object")
+	void shouldOnlyAllowDisabledPropertiesOnTypeObject() {
+
+		assertThatThrownBy(() -> getMappingBuilder().buildPropertyMapping(InvalidDisabledMappingProperty.class))
+				.isInstanceOf(MappingException.class);
+	}
+
+	@Test
+	@DisplayName("should match confidence interval parameter for dense_vector type")
+	void shouldMatchConfidenceIntervalParameterForDenseVectorType() {
+
+		assertThatThrownBy(() -> getMappingBuilder().buildPropertyMapping(DenseVectorMisMatchConfidenceIntervalClass.class))
+				.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test // #1711
+	@DisplayName("should write typeHint entries")
+	void shouldWriteTypeHintEntries() throws JSONException {
+
+		String expected = """
+				{
+				  "properties": {
+				    "_class": {
+				      "type": "keyword",
+				      "index": false,
+				      "doc_values": false
+				    },
+				    "id": {
+				      "type": "keyword"
+				    },
+				    "nestedEntity": {
+				      "type": "nested",
+				      "properties": {
+				        "_class": {
+				          "type": "keyword",
+				          "index": false,
+				          "doc_values": false
+				        },
+				        "nestedField": {
+				          "type": "text"
+				        }
+				      }
+				    },
+				    "objectEntity": {
+				      "type": "object",
+				      "properties": {
+				        "_class": {
+				          "type": "keyword",
+				          "index": false,
+				          "doc_values": false
+				        },
+				        "objectField": {
+				          "type": "text"
+				        }
+				      }
+				    }
+				  }
+				}
+				"""; //
+
+		String mapping = getMappingBuilder().buildPropertyMapping(TypeHintEntity.class);
+
+		assertEquals(expected, mapping, false);
+	}
+
+	@Test // #1727
+	@DisplayName("should map according to the annotated properties")
+	void shouldMapAccordingToTheAnnotatedProperties() throws JSONException {
+
+		String expected = """
+				{
+				    "properties": {
+				        "field1": {
+				            "type": "date",
+				            "format": "date_optional_time||epoch_millis"
+				        },
+				        "field2": {
+				            "type": "date",
+				            "format": "basic_date"
+				        },
+				        "field3": {
+				            "type": "date",
+				            "format": "basic_date||basic_time"
+				        },
+				        "field4": {
+				            "type": "date",
+				            "format": "date_optional_time||epoch_millis||dd.MM.uuuu"
+				        },
+				        "field5": {
+				            "type": "date",
+				            "format": "dd.MM.uuuu"
+				        }
+				    }
+				}"""; //
+
+		String mapping = getMappingBuilder().buildPropertyMapping(DateFormatsEntity.class);
+
+		assertEquals(expected, mapping, false);
+	}
+
+	@Test // #2102
+	@DisplayName("should write date formats for date range fields")
+	void shouldWriteDateFormatsForDateRangeFields() throws JSONException {
+
+		String expected = """
+				{
+				  "properties": {
+				    "_class": {
+				      "type": "keyword",
+				      "index": false,
+				      "doc_values": false
+				    },
+				    "field2": {
+				      "type": "date_range",
+				      "format": "date"
+				    }
+				  }
+				}
+				"""; //
+
+		String mapping = getMappingBuilder().buildPropertyMapping(DateRangeEntity.class);
+
+		assertEquals(expected, mapping, false);
+	}
+
+	@Test // #1454
+	@DisplayName("should write type hints when context is configured to do so")
+	void shouldWriteTypeHintsWhenContextIsConfiguredToDoSo() throws JSONException {
+
+		((SimpleElasticsearchMappingContext) (elasticsearchConverter.get().getMappingContext())).setWriteTypeHints(true);
+		String expected = """
+				{
+				  "properties": {
+				    "_class": {
+				      "type": "keyword",
+				      "index": false,
+				      "doc_values": false
+				    },
+				    "title": {
+				      "type": "text"
+				    },
+				    "authors": {
+				      "type": "nested",
+				      "properties": {
+				        "_class": {
+				          "type": "keyword",
+				          "index": false,
+				          "doc_values": false
+				        }
+				      }
+				    }
+				  }
+				}
+				"""; //
+
+		String mapping = getMappingBuilder().buildPropertyMapping(Magazine.class);
+
+		assertEquals(expected, mapping, true);
+	}
+
+	@Test // #1454
+	@DisplayName("should not write type hints when context is configured to not do so")
+	void shouldNotWriteTypeHintsWhenContextIsConfiguredToNotDoSo() throws JSONException {
+
+		((SimpleElasticsearchMappingContext) (elasticsearchConverter.get().getMappingContext())).setWriteTypeHints(false);
+		String expected = """
+				{
+				  "properties": {
+				    "title": {
+				      "type": "text"
+				    },
+				    "authors": {
+				      "type": "nested",
+				      "properties": {
+				      }
+				    }
+				  }
+				}
+				"""; //
+
+		String mapping = getMappingBuilder().buildPropertyMapping(Magazine.class);
+
+		assertEquals(expected, mapping, true);
+	}
+
+	@Test // #1454
+	@DisplayName("should write type hints when context is configured to not do so but entity should")
+	void shouldWriteTypeHintsWhenContextIsConfiguredToNotDoSoButEntityShould() throws JSONException {
+
+		((SimpleElasticsearchMappingContext) (elasticsearchConverter.get().getMappingContext())).setWriteTypeHints(false);
+		String expected = """
+				{
+				  "properties": {
+				    "_class": {
+				      "type": "keyword",
+				      "index": false,
+				      "doc_values": false
+				    },
+				    "title": {
+				      "type": "text"
+				    },
+				    "authors": {
+				      "type": "nested",
+				      "properties": {
+				        "_class": {
+				          "type": "keyword",
+				          "index": false,
+				          "doc_values": false
+				        }
+				      }
+				    }
+				  }
+				}
+				"""; //
+
+		String mapping = getMappingBuilder().buildPropertyMapping(MagazineWithTypeHints.class);
+
+		assertEquals(expected, mapping, true);
+	}
+
+	@Test // #1454
+	@DisplayName("should not write type hints when context is configured to do so but entity should not")
+	void shouldNotWriteTypeHintsWhenContextIsConfiguredToDoSoButEntityShouldNot() throws JSONException {
+
+		((SimpleElasticsearchMappingContext) (elasticsearchConverter.get().getMappingContext())).setWriteTypeHints(true);
+		String expected = """
+				{
+				  "properties": {
+				    "title": {
+				      "type": "text"
+				    },
+				    "authors": {
+				      "type": "nested",
+				      "properties": {
+				      }
+				    }
+				  }
+				}
+				"""; //
+
+		String mapping = getMappingBuilder().buildPropertyMapping(MagazineWithoutTypeHints.class);
+
+		assertEquals(expected, mapping, true);
+	}
+
+	@Test // #638
+	@DisplayName("should not write dynamic detection mapping entries in default setting")
+	void shouldNotWriteDynamicDetectionMappingEntriesInDefaultSetting() throws JSONException {
+
+		String expected = """
+				{
+				  "properties": {
+				    "_class": {
+				      "type": "keyword",
+				      "index": false,
+				      "doc_values": false
+				    }
+				  }
+				}"""; //
+
+		String mapping = getMappingBuilder().buildPropertyMapping(DynamicDetectionMappingDefault.class);
+
+		assertEquals(expected, mapping, true);
+	}
+
+	@Test // #638
+	@DisplayName("should write dynamic detection mapping entries when set to false")
+	void shouldWriteDynamicDetectionMappingEntriesWhenSetToFalse() throws JSONException {
+
+		String expected = """
+				{
+				  "date_detection": false,  "numeric_detection": false,  "properties": {
+				    "_class": {
+				      "type": "keyword",
+				      "index": false,
+				      "doc_values": false
+				    }
+				  }
+				}"""; //
+
+		String mapping = getMappingBuilder().buildPropertyMapping(DynamicDetectionMappingFalse.class);
+
+		assertEquals(expected, mapping, true);
+	}
+
+	@Test // #638
+	@DisplayName("should write dynamic detection mapping entries when set to true")
+	void shouldWriteDynamicDetectionMappingEntriesWhenSetToTrue() throws JSONException {
+
+		String expected = """
+				{
+				  "date_detection": true,  "numeric_detection": true,  "properties": {
+				    "_class": {
+				      "type": "keyword",
+				      "index": false,
+				      "doc_values": false
+				    }
+				  }
+				}"""; //
+
+		String mapping = getMappingBuilder().buildPropertyMapping(DynamicDetectionMappingTrue.class);
+
+		assertEquals(expected, mapping, true);
+	}
+
+	@Test // #638
+	@DisplayName("should write dynamic date formats")
+	void shouldWriteDynamicDateFormats() throws JSONException {
+
+		String expected = """
+				{
+				  "dynamic_date_formats": ["date1","date2"],  "properties": {
+				    "_class": {
+				      "type": "keyword",
+				      "index": false,
+				      "doc_values": false
+				    }
+				  }
+				}"""; //
+
+		String mapping = getMappingBuilder().buildPropertyMapping(DynamicDateFormatsMapping.class);
+
+		assertEquals(expected, mapping, true);
+	}
+
+	@Test // #1816
+	@DisplayName("should write derived fields")
+	void shouldWriteDerivedFields() throws JSONException {
+
+		String expected = """
+				{
+				  "runtime": {
+				    "day_of_week": {
+				      "type": "keyword",
+				      "script": {
+				        "source": "emit(doc['@timestamp'].value.dayOfWeekEnum.getDisplayName(TextStyle.FULL, Locale.ROOT))"
+				      }
+				    }
+				  },
+				  "properties": {
+				    "_class": {
+				      "type": "keyword",
+				      "index": false,
+				      "doc_values": false
+				    },
+				    "@timestamp": {
+				      "type": "date",
+				      "format": "epoch_millis"
+				    }
+				  }
+				}
+				"""; //
+
+		String mapping = getMappingBuilder().buildPropertyMapping(DerivedFieldEntity.class);
+
+		assertEquals(expected, mapping, true);
+	}
+
+	@Test // #796
+	@DisplayName("should add fields that are excluded from source")
+	void shouldAddFieldsThatAreExcludedFromSource() throws JSONException {
+
+		String expected = """
+				{
+				             "properties": {
+				               "_class": {
+				                 "type": "keyword",
+				                 "index": false,
+				                 "doc_values": false
+				               },
+				               "excluded-date": {
+				                 "type": "date",
+				                 "format": "date"
+				               },
+				               "nestedEntity": {
+				                 "type": "nested",
+				                 "properties": {
+				                   "_class": {
+				                     "type": "keyword",
+				                     "index": false,
+				                     "doc_values": false
+				                   },
+				                   "excluded-text": {
+				                     "type": "text"
+				                   }
+				                 }
+				               },
+				               "excluded-multifield": {
+				                 "type": "text",
+				                 "fields": {
+				                   "keyword": {
+				                     "type": "keyword"
+				                   }
+				                 }
+				               }
+				             },
+				             "_source": {
+				               "excludes": [
+				                 "excluded-date",
+				                 "nestedEntity.excluded-text",
+				                 "excluded-multifield"
+				               ]
+				             }
+
+				              }
+
+				           """; //
+
+		String mapping = getMappingBuilder().buildPropertyMapping(ExcludedFieldEntity.class);
+
+		assertEquals(expected, mapping, true);
+	}
+
+	@Test // #2112
+	@DisplayName("should not write mapping for property with IndexedIndexName anotation")
+	void shouldNotWriteMappingForPropertyWithIndexedIndexNameAnotation() throws JSONException {
+
+		var expected = """
+				{
+				  "properties": {
+				    "_class": {
+				      "type": "keyword",
+				      "index": false,
+				      "doc_values": false
+				    },
+				    "someText": {
+				      "type": "text"
+				    }
+				  }
+				}
+				""";
+		String mapping = getMappingBuilder().buildPropertyMapping(IndexedIndexNameEntity.class);
+
+		assertEquals(expected, mapping, true);
+	}
+
+	@Test // #2502
+	@DisplayName("should use custom name with dots")
+	void shouldUseCustomNameWithDots() throws JSONException {
+
+		var expected = """
+					{
+					  "properties": {
+					    "_class": {
+					      "type": "keyword",
+					      "index": false,
+					      "doc_values": false
+					    },
+					    "dotted.field": {
+					      "type": "text"
+					    }
+					  }
+					}
+				""";
+		String mapping = getMappingBuilder().buildPropertyMapping(FieldNameDotsEntity.class);
+
+		assertEquals(expected, mapping, true);
+	}
+
+	@Test // #2845
+	@DisplayName("should write field aliases to the mapping")
+	void shouldWriteFieldAliasesToTheMapping() throws JSONException {
+
+		var expected = """
+					{
+					  "properties": {
+					    "_class": {
+					      "type": "keyword",
+					      "index": false,
+					      "doc_values": false
+					    },
+					    "someText": {
+					      "type": "text"
+					    },
+					    "otherText": {
+					      "type": "text"
+					    },
+					    "someAlly": {
+					      "type": "alias",
+					      "path": "someText"
+					    },
+					    "otherAlly": {
+					      "type": "alias",
+					      "path": "otherText"
+					    }
+					  }
+					}
+				""";
+		String mapping = getMappingBuilder().buildPropertyMapping(FieldAliasEntity.class);
+
+		assertEquals(expected, mapping, true);
+	}
+
+	@Test // #2942
+	@DisplayName("should use custom  mapped name")
+	void shouldUseCustomMappedName() throws JSONException {
+
+		var expected = """
+					{
+					  "properties": {
+						"_class": {
+						  "type": "keyword",
+						  "index": false,
+						  "doc_values": false
+						},
+						"someText": {
+						  "type": "match_only_text"
+						}
+					  }
+					}
+				""";
+		String mapping = getMappingBuilder().buildPropertyMapping(FieldMappedNameEntity.class);
+
+		assertEquals(expected, mapping, true);
+	}
+
+	@Test // #2942
+	@DisplayName("should use custom  mapped name for multifield")
+	void shouldUseCustomMappedNameMultiField() throws JSONException {
+
+		var expected = """
+					{
+					  "properties": {
+						"_class": {
+						  "type": "keyword",
+						  "index": false,
+						  "doc_values": false
+						},
+						"description": {
+						  "type": "match_only_text",
+						  "fields": {
+							"lower_case": {
+							  "type": "constant_keyword",
+							  "normalizer": "lower_case_normalizer"
+							}
+						  }
+						}
+					  }
+					}
+				""";
+		String mapping = getMappingBuilder().buildPropertyMapping(MultiFieldMappedNameEntity.class);
+
+		assertEquals(expected, mapping, true);
+	}
+
+	@Test // #2952
+	void shouldMapNullityParameters() throws JSONException {
+		// Given
+		String expected = """
+				{
+				   "properties": {
+				     "_class": {
+				       "type": "keyword",
+				       "index": false,
+				       "doc_values": false
+				     },
+				     "empty-field": {
+				       "type": "keyword",
+				       "null_value": "EMPTY",
+				       "fields": {
+				         "suffix": {
+				           "type": "keyword",
+				           "null_value": "EMPTY_TEXT"
+				         }
+				       }
+				     }
+				   }
+				 }
+				""";
+
+		// When
+		String result = getMappingBuilder().buildPropertyMapping(MultiFieldWithNullEmptyParameters.class);
+
+		// Then
+		assertEquals(expected, result, true);
+	}
+
+	// region entities
+
+	@Document(indexName = "ignore-above-index")
+	static class IgnoreAboveEntity {
+		@Nullable
+		@Id private String id;
+		@Nullable
+		@Field(type = FieldType.Keyword, ignoreAbove = 10) private String message;
+
+		@Nullable
+		public String getId() {
+			return id;
+		}
+
+		public void setId(@Nullable String id) {
+			this.id = id;
+		}
+
+		@Nullable
+		public String getMessage() {
+			return message;
+		}
+
+		public void setMessage(@Nullable String message) {
+			this.message = message;
+		}
+	}
+
+	static class FieldNameEntity {
+
+		@Document(indexName = "fieldname-index")
+		static class IdEntity {
+			@Nullable
+			@Id
+			@Field("id-property") private String id;
+		}
+
+		@SuppressWarnings("unused")
+		@Document(indexName = "fieldname-index")
+		static class TextEntity {
+
+			@Nullable
+			@Id
+			@Field("id-property") private String id;
+
+			@Field(name = "text-property", type = FieldType.Text) //
+			@Nullable private String textProperty;
+		}
+
+		@SuppressWarnings("unused")
+		@Document(indexName = "fieldname-index")
+		static class MappingEntity {
+
+			@Nullable
+			@Id
+			@Field("id-property") private String id;
+
+			@Field("mapping-property")
+			@Mapping(mappingPath = "/mappings/test-field-analyzed-mappings.json") //
+			private byte @Nullable [] mappingProperty;
+		}
+
+		@SuppressWarnings("unused")
+		@Document(indexName = "fieldname-index")
+		static class GeoPointEntity {
+
+			@Nullable
+			@Id
+			@Field("id-property") private String id;
+
+			@Nullable
+			@Field("geopoint-property") private GeoPoint geoPoint;
+		}
+
+		@SuppressWarnings("unused")
+		@Document(indexName = "fieldname-index")
+		static class CircularEntity {
+
+			@Nullable
+			@Id
+			@Field("id-property") private String id;
+
+			@Nullable
+			@Field(name = "circular-property", type = FieldType.Object, ignoreFields = { "circular-property" }) //
+			private CircularEntity circularProperty;
+		}
+
+		@SuppressWarnings("unused")
+		@Document(indexName = "fieldname-index")
+		static class CompletionEntity {
+
+			@Nullable
+			@Id
+			@Field("id-property") private String id;
+
+			@Nullable
+			@Field("completion-property")
+			@CompletionField(maxInputLength = 100) //
+			private Completion suggest;
+		}
+
+		@SuppressWarnings("unused")
+		@Document(indexName = "fieldname-index")
+		static class MultiFieldEntity {
+
+			@Nullable
+			@Id
+			@Field("id-property") private String id;
+
+			@Nullable
+			@MultiField(mainField = @Field(name = "main-field", type = FieldType.Text, analyzer = "whitespace"),
+					otherFields = {
+							@InnerField(suffix = "suff-ix", type = FieldType.Text, analyzer = "stop", searchAnalyzer = "standard") }) //
+			private String description;
+
+			@Nullable private String alternateDescription;
+
+			@Nullable
+			@MultiField(mainField = @Field(name = "alternate-description", type = FieldType.Text, analyzer = "whitespace"),
+					otherFields = {
+							@InnerField(suffix = "suff-ix", type = FieldType.Text, analyzer = "stop", searchAnalyzer = "standard") }) //
+			public String getAlternateDescription() {
+				return alternateDescription;
+			}
+
+			public void setAlternateDescription(String alternateDescription) {
+				this.alternateDescription = alternateDescription;
+			}
+
+		}
+	}
+
+	@Document(indexName = "test-index-book-mapping-builder")
+	static class Book {
+		@Nullable
+		@Id private String id;
+		@Nullable private String name;
+		@Nullable
+		@Field(type = FieldType.Object) private Author author;
+		@Nullable
+		@Field(type = FieldType.Nested) private Map<Integer, Collection<String>> buckets = new HashMap<>();
+		@Nullable
+		@MultiField(mainField = @Field(type = FieldType.Text, analyzer = "whitespace"),
+				otherFields = { @InnerField(suffix = "prefix", type = FieldType.Text, analyzer = "stop",
+						searchAnalyzer = "standard") }) private String description;
+
+		@Nullable
+		public String getId() {
+			return id;
+		}
+
+		public void setId(@Nullable String id) {
+			this.id = id;
+		}
+
+		@Nullable
+		public String getName() {
+			return name;
+		}
+
+		public void setName(@Nullable String name) {
+			this.name = name;
+		}
+
+		@Nullable
+		public Author getAuthor() {
+			return author;
+		}
+
+		public void setAuthor(@Nullable Author author) {
+			this.author = author;
+		}
+
+		@Nullable
+		public Map<java.lang.Integer, Collection<String>> getBuckets() {
+			return buckets;
+		}
+
+		public void setBuckets(@Nullable Map<java.lang.Integer, Collection<String>> buckets) {
+			this.buckets = buckets;
+		}
+
+		@Nullable
+		public String getDescription() {
+			return description;
+		}
+
+		public void setDescription(@Nullable String description) {
+			this.description = description;
+		}
+	}
+
+	@SuppressWarnings("unused")
+	@Document(indexName = "test-index-simple-recursive-mapping-builder")
+	static class SimpleRecursiveEntity {
+		@Nullable
+		@Id private String id;
+		@Nullable
+		@Field(type = FieldType.Object, ignoreFields = { "circularObject" }) private SimpleRecursiveEntity circularObject;
+
+		@Nullable
+		public String getId() {
+			return id;
+		}
+
+		public void setId(@Nullable String id) {
+			this.id = id;
+		}
+
+		@Nullable
+		public SimpleRecursiveEntity getCircularObject() {
+			return circularObject;
+		}
+
+		public void setCircularObject(@Nullable SimpleRecursiveEntity circularObject) {
+			this.circularObject = circularObject;
+		}
+	}
+
+	@Document(indexName = "test-copy-to-mapping-builder")
+	static class CopyToEntity {
+		@Nullable
+		@Id private String id;
+		@Nullable
+		@Field(type = FieldType.Keyword, copyTo = "name") private String firstName;
+		@Nullable
+		@Field(type = FieldType.Keyword, copyTo = "name") private String lastName;
+		@Nullable
+		@Field(type = FieldType.Keyword) private String name;
+
+		@Nullable
+		public String getId() {
+			return id;
+		}
+
+		public void setId(@Nullable String id) {
+			this.id = id;
+		}
+
+		@Nullable
+		public String getFirstName() {
+			return firstName;
+		}
+
+		public void setFirstName(@Nullable String firstName) {
+			this.firstName = firstName;
+		}
+
+		@Nullable
+		public String getLastName() {
+			return lastName;
+		}
+
+		public void setLastName(@Nullable String lastName) {
+			this.lastName = lastName;
+		}
+
+		@Nullable
+		public String getName() {
+			return name;
+		}
+
+		public void setName(@Nullable String name) {
+			this.name = name;
+		}
+	}
+
+	@Document(indexName = "test-index-normalizer-mapping-builder")
+	@Setting(settingPath = "/settings/test-normalizer.json")
+	static class NormalizerEntity {
+		@Nullable
+		@Id private String id;
+		@Nullable
+		@Field(type = FieldType.Keyword, normalizer = "lower_case_normalizer") private String name;
+		@Nullable
+		@MultiField(mainField = @Field(type = FieldType.Text), otherFields = { @InnerField(suffix = "lower_case",
+				type = FieldType.Keyword, normalizer = "lower_case_normalizer") }) private String description;
+
+		@Nullable
+		public String getId() {
+			return id;
+		}
+
+		public void setId(@Nullable String id) {
+			this.id = id;
+		}
+
+		@Nullable
+		public String getName() {
+			return name;
+		}
+
+		public void setName(@Nullable String name) {
+			this.name = name;
+		}
+
+		@Nullable
+		public String getDescription() {
+			return description;
+		}
+
+		public void setDescription(@Nullable String description) {
+			this.description = description;
+		}
+	}
+
+	static class Author {
+		@Nullable private String id;
+		@Nullable private String name;
+
+		@Nullable
+		public String getId() {
+			return id;
+		}
+
+		public void setId(String id) {
+			this.id = id;
+		}
+
+		@Nullable
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+	@Document(indexName = "test-index-sample-inherited-mapping-builder")
+	static class SampleInheritedEntity extends AbstractInheritedEntity {
+
+		@Nullable
+		@Field(type = Text, index = false, store = true, analyzer = "standard") private String message;
+
+		@Nullable
+		public String getMessage() {
+			return message;
+		}
+
+		public void setMessage(String message) {
+			this.message = message;
+		}
+	}
+
+	@SuppressWarnings("unused")
+	@Document(indexName = "test-index-stock-mapping-builder")
+	static class StockPrice {
+		@Nullable
+		@Id private String id;
+		@Nullable private String symbol;
+		@Nullable
+		@Field(type = FieldType.Double) private BigDecimal price;
+
+		@Nullable
+		public String getId() {
+			return id;
+		}
+
+		public void setId(@Nullable String id) {
+			this.id = id;
+		}
+
+		@Nullable
+		public String getSymbol() {
+			return symbol;
+		}
+
+		public void setSymbol(@Nullable String symbol) {
+			this.symbol = symbol;
+		}
+
+		@Nullable
+		public BigDecimal getPrice() {
+			return price;
+		}
+
+		public void setPrice(@Nullable BigDecimal price) {
+			this.price = price;
+		}
+	}
+
+	@SuppressWarnings("unused")
+	static class AbstractInheritedEntity {
+
+		@Nullable
+		@Id private String id;
+
+		@Nullable
+		@Field(type = FieldType.Date, format = DateFormat.date_time, index = false) private Date createdDate;
+
+		@Nullable
+		public String getId() {
+			return id;
+		}
+
+		public void setId(String id) {
+			this.id = id;
+		}
+
+		@Nullable
+		public Date getCreatedDate() {
+			return createdDate;
+		}
+
+		public void setCreatedDate(Date createdDate) {
+			this.createdDate = createdDate;
+		}
+	}
+
+	@SuppressWarnings("unused")
+	@Document(indexName = "test-index-recursive-mapping-mapping-builder")
+	static class SampleTransientEntity {
+
+		@Nullable
+		@Id private String id;
+
+		@Nullable
+		@Field(type = Text, index = false, store = true, analyzer = "standard") private String message;
+
+		@Nullable
+		@Transient private NestedEntity nested;
+
+		@Nullable
+		public String getId() {
+			return id;
+		}
+
+		public void setId(String id) {
+			this.id = id;
+		}
+
+		@Nullable
+		public String getMessage() {
+			return message;
+		}
+
+		public void setMessage(String message) {
+			this.message = message;
+		}
+
+		static class NestedEntity {
+
+			@Field private static NestedEntity someField = new NestedEntity();
+			@Nullable
+			@Field private Boolean something;
+
+			public NestedEntity getSomeField() {
+				return someField;
+			}
+
+			public void setSomeField(NestedEntity someField) {
+				NestedEntity.someField = someField;
+			}
+
+			@Nullable
+			public Boolean getSomething() {
+				return something;
+			}
+
+			public void setSomething(Boolean something) {
+				this.something = something;
+			}
+		}
+	}
+
+	@SuppressWarnings("unused")
+	@Document(indexName = "test-index-geo-mapping-builder")
+	static class GeoEntity {
+		@Nullable
+		@Id private String id;
+		// geo shape - Spring Data
+		@Nullable private Box box;
+		@Nullable private Circle circle;
+		@Nullable private Polygon polygon;
+		// geo point - Custom implementation + Spring Data
+		@Nullable
+		@GeoPointField private Point pointA;
+		@Nullable private GeoPoint pointB;
+		@Nullable
+		@GeoPointField private String pointC;
+		@GeoPointField private double @Nullable [] pointD;
+
+		@Nullable
+		@GeoShapeField private String shape1;
+		@Nullable
+		@GeoShapeField(coerce = true, ignoreMalformed = true, ignoreZValue = false,
+				orientation = GeoShapeField.Orientation.clockwise) private String shape2;
+
+		@Nullable
+		public String getId() {
+			return id;
+		}
+
+		public void setId(@Nullable String id) {
+			this.id = id;
+		}
+
+		@Nullable
+		public Box getBox() {
+			return box;
+		}
+
+		public void setBox(@Nullable Box box) {
+			this.box = box;
+		}
+
+		@Nullable
+		public Circle getCircle() {
+			return circle;
+		}
+
+		public void setCircle(@Nullable Circle circle) {
+			this.circle = circle;
+		}
+
+		@Nullable
+		public Polygon getPolygon() {
+			return polygon;
+		}
+
+		public void setPolygon(@Nullable Polygon polygon) {
+			this.polygon = polygon;
+		}
+
+		@Nullable
+		public Point getPointA() {
+			return pointA;
+		}
+
+		public void setPointA(@Nullable Point pointA) {
+			this.pointA = pointA;
+		}
+
+		@Nullable
+		public GeoPoint getPointB() {
+			return pointB;
+		}
+
+		public void setPointB(@Nullable GeoPoint pointB) {
+			this.pointB = pointB;
+		}
+
+		@Nullable
+		public String getPointC() {
+			return pointC;
+		}
+
+		public void setPointC(@Nullable String pointC) {
+			this.pointC = pointC;
+		}
+
+		public double @Nullable [] getPointD() {
+			return pointD;
+		}
+
+		public void setPointD(double @Nullable [] pointD) {
+			this.pointD = pointD;
+		}
+
+		@Nullable
+		public String getShape1() {
+			return shape1;
+		}
+
+		public void setShape1(@Nullable String shape1) {
+			this.shape1 = shape1;
+		}
+
+		@Nullable
+		public String getShape2() {
+			return shape2;
+		}
+
+		public void setShape2(@Nullable String shape2) {
+			this.shape2 = shape2;
+		}
+	}
+
+	@SuppressWarnings("unused")
+	@Document(indexName = "test-index-field-mapping-parameters")
+	static class FieldMappingParameters {
+		@Nullable
+		@Field private String indexTrue;
+		@Nullable
+		@Field(index = false) private String indexFalse;
+		@Nullable
+		@Field(store = true) private String storeTrue;
+		@Nullable
+		@Field private String storeFalse;
+		@Nullable
+		@Field private String coerceTrue;
+		@Nullable
+		@Field(coerce = false) private String coerceFalse;
+		@Nullable
+		@Field(fielddata = true) private String fielddataTrue;
+		@Nullable
+		@Field private String fielddataFalse;
+		@Nullable
+		@Field(copyTo = { "foo", "bar" }) private String copyTo;
+		@Nullable
+		@Field(ignoreAbove = 42) private String ignoreAbove;
+		@Nullable
+		@Field(type = FieldType.Integer) private String type;
+		@Nullable
+		@Field(type = FieldType.Date, format = {}, pattern = "YYYYMMDD") private LocalDate date;
+		@Nullable
+		@Field(analyzer = "ana", searchAnalyzer = "sana", normalizer = "norma") private String analyzers;
+		@Nullable
+		@Field(type = Keyword) private String docValuesTrue;
+		@Nullable
+		@Field(type = Keyword, docValues = false) private String docValuesFalse;
+		@Nullable
+		@Field(ignoreMalformed = true) private String ignoreMalformedTrue;
+		@Nullable
+		@Field() private String ignoreMalformedFalse;
+		@Nullable
+		@Field(indexOptions = IndexOptions.none) private String indexOptionsNone;
+		@Nullable
+		@Field(indexOptions = IndexOptions.positions) private String indexOptionsPositions;
+		@Nullable
+		@Field(indexPhrases = true) private String indexPhrasesTrue;
+		@Nullable
+		@Field() private String indexPhrasesFalse;
+		@Nullable
+		@Field(indexPrefixes = @IndexPrefixes) private String defaultIndexPrefixes;
+		@Nullable
+		@Field(indexPrefixes = @IndexPrefixes(minChars = 1, maxChars = 10)) private String customIndexPrefixes;
+		@Nullable
+		@Field private String normsTrue;
+		@Nullable
+		@Field(norms = false) private String normsFalse;
+		@Nullable
+		@Field private String nullValueNotSet;
+		@Nullable
+		@Field(nullValue = "NULLNULL") private String nullValueString;
+		@Nullable
+		@Field(nullValue = "42", nullValueType = NullValueType.Integer) private String nullValueInteger;
+		@Nullable
+		@Field(nullValue = "42.0", nullValueType = NullValueType.Double) private String nullValueDouble;
+		@Nullable
+		@Field(positionIncrementGap = 42) private String positionIncrementGap;
+		@Nullable
+		@Field private String similarityDefault;
+		@Nullable
+		@Field(similarity = Similarity.Boolean) private String similarityBoolean;
+		@Nullable
+		@Field private String termVectorDefault;
+		@Nullable
+		@Field(termVector = TermVector.with_offsets) private String termVectorWithOffsets;
+		@Nullable
+		@Field(type = FieldType.Scaled_Float, scalingFactor = 100.0) Double scaledFloat;
+		@Nullable
+		@Field(type = Auto) String autoField;
+		@Nullable
+		@Field(type = Object) private String enabledObject;
+		@Nullable
+		@Field(type = Object, enabled = false) private String disabledObject;
+		@Nullable
+		@Field(type = Text, eagerGlobalOrdinals = true) private String eagerGlobalOrdinalsTrue;
+		@Nullable
+		@Field(type = Text) private String eagerGlobalOrdinalsFalse;
+		@Nullable
+		@Field(type = Wildcard) private String wildcardWithoutParams;
+		@Nullable
+		@Field(type = Wildcard, nullValue = "WILD", ignoreAbove = 42) private String wildcardWithParams;
+	}
+
+	@SuppressWarnings("unused")
+	@Document(indexName = "test-index-configure-dynamic-mapping", dynamic = Dynamic.FALSE)
+	static class DynamicMappingAnnotationEntity {
+
+		@Nullable
+		@Field(type = FieldType.Object, dynamic = Dynamic.STRICT) private Author author;
+		@Nullable
+		@Field(type = FieldType.Object, dynamic = Dynamic.FALSE) private Map<String, Object> objectMap;
+		@Nullable
+		@Field(type = FieldType.Nested, dynamic = Dynamic.FALSE) private List<Map<String, Object>> nestedObjectMap;
+
+		@Nullable
+		public Author getAuthor() {
+			return author;
+		}
+
+		public void setAuthor(Author author) {
+			this.author = author;
+		}
+	}
+
+	@SuppressWarnings("unused")
+	@Document(indexName = "test-index-configure-dynamic-mapping", dynamic = Dynamic.FALSE)
+	static class DynamicMappingEntity {
+
+		@Nullable
+		@Field(type = FieldType.Object) //
+		private Map<String, Object> objectInherit;
+		@Nullable
+		@Field(type = FieldType.Object, dynamic = Dynamic.FALSE) //
+		private Map<String, Object> objectFalse;
+		@Nullable
+		@Field(type = FieldType.Object, dynamic = Dynamic.TRUE) //
+		private Map<String, Object> objectTrue;
+		@Nullable
+		@Field(type = FieldType.Object, dynamic = Dynamic.STRICT) //
+		private Map<String, Object> objectStrict;
+		@Nullable
+		@Field(type = FieldType.Object, dynamic = Dynamic.RUNTIME) //
+		private Map<String, Object> objectRuntime;
+		@Nullable
+		@Field(type = FieldType.Nested) //
+		private List<Map<String, Object>> nestedObjectInherit;
+		@Nullable
+		@Field(type = FieldType.Nested, dynamic = Dynamic.FALSE) //
+		private List<Map<String, Object>> nestedObjectFalse;
+		@Nullable
+		@Field(type = FieldType.Nested, dynamic = Dynamic.TRUE) //
+		private List<Map<String, Object>> nestedObjectTrue;
+		@Nullable
+		@Field(type = FieldType.Nested, dynamic = Dynamic.STRICT) //
+		private List<Map<String, Object>> nestedObjectStrict;
+		@Nullable
+		@Field(type = FieldType.Nested, dynamic = Dynamic.RUNTIME) //
+		private List<Map<String, Object>> nestedObjectRuntime;
+
+	}
+
+	record ValueObject(String value) {
+	}
+
+	@SuppressWarnings("unused")
+	@Document(indexName = "valueDoc")
+	static class ValueDoc {
+		@Nullable
+		@Field(type = Text) private ValueObject valueObject;
+	}
+
+	@SuppressWarnings("unused")
+	@Document(indexName = "completion")
+	static class CompletionDocument {
+		@Nullable
+		@Id private String id;
+		@Nullable
+		@CompletionField(contexts = { @CompletionContext(name = "location", type = CompletionContext.ContextMappingType.GEO,
+				path = "proppath") }) private Completion suggest;
+
+		@Nullable
+		public String getId() {
+			return id;
+		}
+
+		public void setId(@Nullable String id) {
+			this.id = id;
+		}
+
+		@Nullable
+		public Completion getSuggest() {
+			return suggest;
+		}
+
+		public void setSuggest(@Nullable Completion suggest) {
+			this.suggest = suggest;
+		}
+	}
+
+	@SuppressWarnings("unused")
+	@Document(indexName = "test-index-entity-with-seq-no-primary-term-mapping-builder")
+	static class EntityWithSeqNoPrimaryTerm {
+		@Field(type = Object)
+		@Nullable private SeqNoPrimaryTerm seqNoPrimaryTerm;
+
+		@Nullable
+		public SeqNoPrimaryTerm getSeqNoPrimaryTerm() {
+			return seqNoPrimaryTerm;
+		}
+
+		public void setSeqNoPrimaryTerm(SeqNoPrimaryTerm seqNoPrimaryTerm) {
+			this.seqNoPrimaryTerm = seqNoPrimaryTerm;
+		}
+	}
+
+	@SuppressWarnings("unused")
+	static class RankFeatureEntity {
+		@Nullable
+		@Id private String id;
+		@Nullable
+		@Field(type = FieldType.Rank_Feature) private Integer pageRank;
+		@Nullable
+		@Field(type = FieldType.Rank_Feature, positiveScoreImpact = false) private Integer urlLength;
+		@Nullable
+		@Field(type = FieldType.Rank_Features) private Map<String, Integer> topics;
+
+		@Nullable
+		public String getId() {
+			return id;
+		}
+
+		public void setId(@Nullable String id) {
+			this.id = id;
+		}
+
+		public java.lang.@Nullable Integer getPageRank() {
+			return pageRank;
+		}
+
+		public void setPageRank(java.lang.@Nullable Integer pageRank) {
+			this.pageRank = pageRank;
+		}
+
+		public java.lang.@Nullable Integer getUrlLength() {
+			return urlLength;
+		}
+
+		public void setUrlLength(java.lang.@Nullable Integer urlLength) {
+			this.urlLength = urlLength;
+		}
+
+		@Nullable
+		public Map<String, java.lang.Integer> getTopics() {
+			return topics;
+		}
+
+		public void setTopics(@Nullable Map<String, java.lang.Integer> topics) {
+			this.topics = topics;
+		}
+	}
+
+	@SuppressWarnings("unused")
+	static class DenseVectorEntity {
+		@Nullable
+		@Id private String id;
+		@Field(type = FieldType.Dense_Vector, dims = 16, mappedTypeName = "knn_vector") private float @Nullable [] my_vector;
+
+		@Nullable
+		public String getId() {
+			return id;
+		}
+
+		public void setId(@Nullable String id) {
+			this.id = id;
+		}
+
+		public float @Nullable [] getMy_vector() {
+			return my_vector;
+		}
+
+		public void setMy_vector(float @Nullable [] my_vector) {
+			this.my_vector = my_vector;
+		}
+	}
+
+	@SuppressWarnings("unused")
+	static class DenseVectorEntityWithKnnSearch {
+		@Nullable
+		@Id private String id;
+
+		@Field(type = FieldType.Dense_Vector, dims = 16, elementType = FieldElementType.FLOAT, mappedTypeName = "knn_vector",
+				knnIndexOptions = @KnnIndexOptions(type = KnnAlgorithmType.HNSW, m = 16, efConstruction = 100),
+				knnSimilarity = KnnSimilarity.DOT_PRODUCT) private float @Nullable [] my_vector;
+
+		@Nullable
+		public String getId() {
+			return id;
+		}
+
+		public void setId(@Nullable String id) {
+			this.id = id;
+		}
+
+		public float @Nullable [] getMy_vector() {
+			return my_vector;
+		}
+
+		public void setMy_vector(float @Nullable [] my_vector) {
+			this.my_vector = my_vector;
+		}
+	}
+
+	@Mapping(enabled = false)
+	static class DisabledMappingEntity {
+		@Nullable
+		@Id private String id;
+		@Nullable
+		@Field(type = Text) private String text;
+
+		@Nullable
+		public String getId() {
+			return id;
+		}
+
+		public void setId(@Nullable String id) {
+			this.id = id;
+		}
+
+		@Nullable
+		public String getText() {
+			return text;
+		}
+
+		public void setText(@Nullable String text) {
+			this.text = text;
+		}
+	}
+
+	static class InvalidDisabledMappingProperty {
+		@Nullable
+		@Id private String id;
+		@Nullable
+		@Mapping(enabled = false)
+		@Field(type = Text) private String text;
+
+		@Nullable
+		public String getId() {
+			return id;
+		}
+
+		public void setId(@Nullable String id) {
+			this.id = id;
+		}
+
+		@Nullable
+		public String getText() {
+			return text;
+		}
+
+		public void setText(@Nullable String text) {
+			this.text = text;
+		}
+	}
+
+	static class DenseVectorMisMatchConfidenceIntervalClass {
+		@Field(type = Dense_Vector, dims = 16, elementType = FieldElementType.FLOAT,
+				knnIndexOptions = @KnnIndexOptions(type = KnnAlgorithmType.HNSW, m = 16, confidenceInterval = 0.95F),
+				knnSimilarity = KnnSimilarity.DOT_PRODUCT) private float @Nullable [] dense_vector;
+	}
+
+	static class DisabledMappingProperty {
+		@Nullable
+		@Id private String id;
+		@Nullable
+		@Field(type = Text) private String text;
+		@Nullable
+		@Mapping(enabled = false)
+		@Field(type = Object) private Object object;
+
+		@Nullable
+		public String getId() {
+			return id;
+		}
+
+		public void setId(@Nullable String id) {
+			this.id = id;
+		}
+
+		@Nullable
+		public String getText() {
+			return text;
+		}
+
+		public void setText(@Nullable String text) {
+			this.text = text;
+		}
+
+		public java.lang.@Nullable Object getObject() {
+			return object;
+		}
+
+		public void setObject(java.lang.@Nullable Object object) {
+			this.object = object;
+		}
+	}
+
+	@SuppressWarnings("unused")
+	static class TypeHintEntity {
+		@Nullable
+		@Id
+		@Field(type = Keyword) private String id;
+		@Nullable
+		@Field(type = Nested) private NestedEntity nestedEntity;
+		@Nullable
+		@Field(type = Object) private ObjectEntity objectEntity;
+
+		@Nullable
+		public String getId() {
+			return id;
+		}
+
+		public void setId(@Nullable String id) {
+			this.id = id;
+		}
+
+		@Nullable
+		public NestedEntity getNestedEntity() {
+			return nestedEntity;
+		}
+
+		public void setNestedEntity(@Nullable NestedEntity nestedEntity) {
+			this.nestedEntity = nestedEntity;
+		}
+
+		@Nullable
+		public ObjectEntity getObjectEntity() {
+			return objectEntity;
+		}
+
+		public void setObjectEntity(@Nullable ObjectEntity objectEntity) {
+			this.objectEntity = objectEntity;
+		}
+
+		static class NestedEntity {
+			@Nullable
+			@Field(type = Text) private String nestedField;
+
+			@Nullable
+			public String getNestedField() {
+				return nestedField;
+			}
+
+			public void setNestedField(@Nullable String nestedField) {
+				this.nestedField = nestedField;
+			}
+		}
+
+		static class ObjectEntity {
+			@Nullable
+			@Field(type = Text) private String objectField;
+
+			@Nullable
+			public String getObjectField() {
+				return objectField;
+			}
+
+			public void setObjectField(@Nullable String objectField) {
+				this.objectField = objectField;
+			}
+		}
+	}
+
+	@SuppressWarnings("unused")
+	static class DateFormatsEntity {
+		@Nullable
+		@Id private String id;
+		@Nullable
+		@Field(type = FieldType.Date) private LocalDateTime field1;
+		@Nullable
+		@Field(type = FieldType.Date, format = DateFormat.basic_date) private LocalDateTime field2;
+		@Nullable
+		@Field(type = FieldType.Date,
+				format = { DateFormat.basic_date, DateFormat.basic_time }) private LocalDateTime field3;
+		@Nullable
+		@Field(type = FieldType.Date, pattern = "dd.MM.uuuu") private LocalDateTime field4;
+		@Nullable
+		@Field(type = FieldType.Date, format = {}, pattern = "dd.MM.uuuu") private LocalDateTime field5;
+
+		@Nullable
+		public String getId() {
+			return id;
+		}
+
+		public void setId(@Nullable String id) {
+			this.id = id;
+		}
+
+		@Nullable
+		public LocalDateTime getField1() {
+			return field1;
+		}
+
+		public void setField1(@Nullable LocalDateTime field1) {
+			this.field1 = field1;
+		}
+
+		@Nullable
+		public LocalDateTime getField2() {
+			return field2;
+		}
+
+		public void setField2(@Nullable LocalDateTime field2) {
+			this.field2 = field2;
+		}
+
+		@Nullable
+		public LocalDateTime getField3() {
+			return field3;
+		}
+
+		public void setField3(@Nullable LocalDateTime field3) {
+			this.field3 = field3;
+		}
+
+		@Nullable
+		public LocalDateTime getField4() {
+			return field4;
+		}
+
+		public void setField4(@Nullable LocalDateTime field4) {
+			this.field4 = field4;
+		}
+
+		@Nullable
+		public LocalDateTime getField5() {
+			return field5;
+		}
+
+		public void setField5(@Nullable LocalDateTime field5) {
+			this.field5 = field5;
+		}
+	}
+
+	@SuppressWarnings("unused")
+	private static class DateRangeEntity {
+		@Nullable
+		@Id private String id;
+		@Nullable
+		@Field(type = Date_Range, format = DateFormat.date) private Range<LocalDateTime> field2;
+
+		@Nullable
+		public String getId() {
+			return id;
+		}
+
+		public void setId(@Nullable String id) {
+			this.id = id;
+		}
+
+		@Nullable
+		public Range<LocalDateTime> getField2() {
+			return field2;
+		}
+
+		public void setField2(@Nullable Range<LocalDateTime> field2) {
+			this.field2 = field2;
+		}
+	}
+
+	@SuppressWarnings("unused")
+	@Document(indexName = "magazine")
+	private static class Magazine {
+		@Id
+		@Nullable private String id;
+		@Field(type = Text)
+		@Nullable private String title;
+		@Field(type = Nested)
+		@Nullable private List<Author> authors;
+	}
+
+	@SuppressWarnings("unused")
+	@Document(indexName = "magazine-without-type-hints", writeTypeHint = WriteTypeHint.FALSE)
+	private static class MagazineWithoutTypeHints {
+		@Id
+		@Nullable private String id;
+		@Field(type = Text)
+		@Nullable private String title;
+		@Field(type = Nested)
+		@Nullable private List<Author> authors;
+	}
+
+	@SuppressWarnings("unused")
+	@Document(indexName = "magazine-with-type-hints", writeTypeHint = WriteTypeHint.TRUE)
+	private static class MagazineWithTypeHints {
+		@Id
+		@Nullable private String id;
+		@Field(type = Text)
+		@Nullable private String title;
+		@Field(type = Nested)
+		@Nullable private List<Author> authors;
+	}
+
+	@Document(indexName = "dynamic-field-mapping-default")
+	private static class DynamicDetectionMappingDefault {
+		@Id
+		@Nullable private String id;
+	}
+
+	@Document(indexName = "dynamic-dateformats-mapping")
+	@Mapping(dynamicDateFormats = { "date1", "date2" })
+	private static class DynamicDateFormatsMapping {
+		@Id
+		@Nullable private String id;
+	}
+
+	@Document(indexName = "dynamic-detection-mapping-true")
+	@Mapping(dateDetection = Mapping.Detection.TRUE, numericDetection = Mapping.Detection.TRUE)
+	private static class DynamicDetectionMappingTrue {
+		@Id
+		@Nullable private String id;
+	}
+
+	@Document(indexName = "dynamic-detection-mapping-false")
+	@Mapping(dateDetection = Mapping.Detection.FALSE, numericDetection = Mapping.Detection.FALSE)
+	private static class DynamicDetectionMappingFalse {
+		@Id
+		@Nullable private String id;
+	}
+
+	@SuppressWarnings("unused")
+	@Document(indexName = "derived-fields")
+	@Mapping(runtimeFieldsPath = "/mappings/derived-fields.json")
+	private static class DerivedFieldEntity {
+		@Id
+		@Nullable private String id;
+		@Field(type = Date, format = DateFormat.epoch_millis, name = "@timestamp")
+		@Nullable private Instant timestamp;
+	}
+
+	@SuppressWarnings("unused")
+	@Document(indexName = "fields-excluded-from-source")
+	private static class ExcludedFieldEntity {
+		@Id
+		@Nullable private String id;
+		@Nullable
+		@Field(name = "excluded-date", type = Date, format = DateFormat.date,
+				excludeFromSource = true) private LocalDate excludedDate;
+		@Nullable
+		@Field(type = Nested) private NestedExcludedFieldEntity nestedEntity;
+		@Nullable
+		@MultiField(mainField = @Field(name = "excluded-multifield", type = Text, excludeFromSource = true), otherFields = {
+				@InnerField(suffix = "keyword", type = Keyword)
+		}) private String excludedMultifield;
+	}
+
+	@SuppressWarnings("unused")
+	private static class NestedExcludedFieldEntity {
+		@Nullable
+		@Field(name = "excluded-text", type = Text, excludeFromSource = true) private String excludedText;
+	}
+
+	@SuppressWarnings("unused")
+	private static class IndexedIndexNameEntity {
+		@Nullable
+		@Field(type = Text) private String someText;
+		@Nullable
+		@IndexedIndexName private String storedIndexName;
+	}
+
+	@SuppressWarnings("unused")
+	private static class FieldNameDotsEntity {
+		@Id
+		@Nullable private String id;
+		@Nullable
+		@Field(name = "dotted.field", type = Text) private String dottedField;
+	}
+
+	@Mapping(aliases = {
+			@MappingAlias(name = "someAlly", path = "someText"),
+			@MappingAlias(name = "otherAlly", path = "otherText")
+	})
+	private static class FieldAliasEntity {
+		@Id
+		@Nullable private String id;
+		@Nullable
+		@Field(type = Text) private String someText;
+		@Nullable
+		@Field(type = Text) private String otherText;
+	}
+
+	@SuppressWarnings("unused")
+	private static class FieldMappedNameEntity {
+		@Nullable
+		@Field(type = Text, mappedTypeName = "match_only_text") private String someText;
+	}
+
+	@SuppressWarnings("unused")
+	private static class MultiFieldMappedNameEntity {
+		@Nullable
+		@MultiField(mainField = @Field(type = FieldType.Text, mappedTypeName = "match_only_text"),
+				otherFields = { @InnerField(suffix = "lower_case",
+						type = FieldType.Keyword, normalizer = "lower_case_normalizer",
+						mappedTypeName = "constant_keyword") }) private String description;
+	}
+
+	@SuppressWarnings("unused")
+	private static class MultiFieldWithNullEmptyParameters {
+		@Nullable
+		@MultiField(
+				mainField = @Field(name = "empty-field", type = FieldType.Keyword, nullValue = "EMPTY", storeNullValue = true),
+				otherFields = {
+						@InnerField(suffix = "suffix", type = Keyword, nullValue = "EMPTY_TEXT") }) private List<String> emptyField;
+	}
+	// endregion
+}

--- a/spring-data-opensearch/src/test/java/org/springframework/data/elasticsearch/repositories/knn/KnnSearchIntegrationTests.java
+++ b/spring-data-opensearch/src/test/java/org/springframework/data/elasticsearch/repositories/knn/KnnSearchIntegrationTests.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2024-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.repositories.knn;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.data.elasticsearch.annotations.FieldType.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldElementType;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.KnnAlgorithmType;
+import org.springframework.data.elasticsearch.annotations.KnnIndexOptions;
+import org.springframework.data.elasticsearch.annotations.KnnSimilarity;
+import org.springframework.data.elasticsearch.annotations.Setting;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
+import org.springframework.data.elasticsearch.core.query.Query;
+import org.springframework.data.elasticsearch.junit.jupiter.SpringIntegrationTest;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+import org.springframework.data.elasticsearch.utils.IndexNameProvider;
+
+/**
+ * @author Haibo Liu
+ * @since 5.4
+ */
+@SpringIntegrationTest
+public abstract class KnnSearchIntegrationTests {
+
+	@Autowired ElasticsearchOperations operations;
+	@Autowired private IndexNameProvider indexNameProvider;
+	@Autowired private VectorEntityRepository vectorEntityRepository;
+
+	@BeforeEach
+	public void before() {
+		indexNameProvider.increment();
+		operations.indexOps(VectorEntity.class).createWithMapping();
+	}
+
+	@Test
+	@org.junit.jupiter.api.Order(java.lang.Integer.MAX_VALUE)
+	void cleanup() {
+		operations.indexOps(IndexCoordinates.of(indexNameProvider.getPrefix() + "*")).delete();
+	}
+
+	private List<VectorEntity> createVectorEntities(int n) {
+		List<VectorEntity> entities = new ArrayList<>();
+		float increment = 1.0f / n;
+		for (int i = 0; i < n; i++) {
+			VectorEntity entity = new VectorEntity();
+			entity.setId(UUID.randomUUID().toString());
+			entity.setMessage("top" + (i + 1));
+
+			// The generated vector is always in the first quadrant, from the x-axis direction to the y-axis direction
+			float[] vector = new float[] { 1.0f - i * increment, increment };
+			entity.setVector(vector);
+			entities.add(entity);
+		}
+
+		return entities;
+	}
+
+	@Test
+	public void shouldReturnXAxisVector() {
+
+		// given
+		List<VectorEntity> entities = createVectorEntities(5);
+		vectorEntityRepository.saveAll(entities);
+		List<Float> xAxisVector = List.of(100f, 0f);
+
+		// when
+		SearchHits<VectorEntity> result = operations.search(getQuery(xAxisVector), VectorEntity.class);
+
+		List<VectorEntity> vectorEntities = result.getSearchHits().stream().map(SearchHit::getContent).toList();
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getTotalHits()).isEqualTo(3L);
+		// should return the first vector, because it's near x-axis
+		assertThat(vectorEntities.get(0).getMessage()).isEqualTo("top1");
+	}
+
+	@Test
+	public void shouldReturnYAxisVector() {
+
+		// given
+		List<VectorEntity> entities = createVectorEntities(10);
+		vectorEntityRepository.saveAll(entities);
+		List<Float> yAxisVector = List.of(0f, 100f);
+
+		// when
+		SearchHits<VectorEntity> result = operations.search(getQuery(yAxisVector), VectorEntity.class);
+
+		List<VectorEntity> vectorEntities = result.getSearchHits().stream().map(SearchHit::getContent).toList();
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getTotalHits()).isEqualTo(3L);
+		// should return the last vector, because it's near y-axis
+		assertThat(vectorEntities.get(0).getMessage()).isEqualTo("top10");
+	}
+	
+	protected abstract Query getQuery(List<Float> vector);
+
+	public interface VectorEntityRepository extends ElasticsearchRepository<VectorEntity, String> {}
+
+	@Setting(settingPath = "settings/knn-settings.json")
+	@Document(indexName = "#{@indexNameProvider.indexName()}")
+	static class VectorEntity {
+		@Nullable
+		@Id private String id;
+
+		@Nullable
+		@Field(type = Keyword) private String message;
+
+		@Field(type = FieldType.Dense_Vector, mappedTypeName = "knn_vector", dims = 2, elementType = FieldElementType.FLOAT,
+				knnIndexOptions = @KnnIndexOptions(type = KnnAlgorithmType.HNSW, m = 16, efConstruction = 100),
+				knnSimilarity = KnnSimilarity.COSINE) private float[] vector;
+
+		@Nullable
+		public String getId() {
+			return id;
+		}
+
+		public void setId(@Nullable String id) {
+			this.id = id;
+		}
+
+		@Nullable
+		public String getMessage() {
+			return message;
+		}
+
+		public void setMessage(@Nullable String message) {
+			this.message = message;
+		}
+
+		public float @Nullable [] getVector() {
+			return vector;
+		}
+
+		public void setVector(float @Nullable [] vector) {
+			this.vector = vector;
+		}
+	}
+}

--- a/spring-data-opensearch/src/test/resources/mappings/derived-fields.json
+++ b/spring-data-opensearch/src/test/resources/mappings/derived-fields.json
@@ -1,0 +1,8 @@
+{
+  "day_of_week": {
+    "type": "keyword",
+    "script": {
+      "source": "emit(doc['@timestamp'].value.dayOfWeekEnum.getDisplayName(TextStyle.FULL, Locale.ROOT))"
+    }
+  }
+}

--- a/spring-data-opensearch/src/test/resources/settings/knn-settings.json
+++ b/spring-data-opensearch/src/test/resources/settings/knn-settings.json
@@ -1,0 +1,7 @@
+{
+    "index": {
+        "number_of_shards": "1",
+        "number_of_replicas": "0",
+        "knn": true
+    }
+}


### PR DESCRIPTION
### Description
Support knn_vector field type. The current solution addresses most (but not all) of the issues while staying in spirit with Spring Data Elasticsearch:
 - no new annotations, we still relying on `@Field` + its `mappedTypeName` attribute (example below), that allows us to cover all supported features (repositories, rest/client templates, etc.)
    ```
    	@Field(type = FieldType.Dense_Vector, mappedTypeName = "knn_vector", dims = 2, elementType = FieldElementType.FLOAT,
    				knnIndexOptions = @KnnIndexOptions(type = KnnAlgorithmType.HNSW, m = 16, efConstruction = 100),
    				knnSimilarity = KnnSimilarity.COSINE) private float[] vector;
    ``` 
 - attributes of K-NN field (`knnIndexOptions` , `knnSimilarity` , ...) do not map directly to OpenSearch and this translation is done by `OpenSearchMappingParametersCustomizer` / `OpenSearchMappingParameters` pair
 - notably, the `knnSimilarity` maps to:
 ```java
            case COSINE: return "cosinesimil";
            case L2_NORM: return "l2";
            case DOT_PRODUCT: return "innerproduct";
            case MAX_INNER_PRODUCT: return "innerproduct";
 ```
 - and the only supported `KnnAlgorithmType` at the moment is `HNSW`

### Issues Resolved
Closes https://github.com/opensearch-project/spring-data-opensearch/issues/124

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
