### PR TITLE
[2.0.x] add AOT & native image support

### DIFF
--- a/.github/workflows/main_and_pr_workflow.yml
+++ b/.github/workflows/main_and_pr_workflow.yml
@@ -51,3 +51,15 @@ jobs:
           cache: gradle
       - name: Check with Gradle
         run: ./gradlew check -Psde.testcontainers.image-version=${{ matrix.entry.opensearch-version }}
+
+  check-native-image:
+    name: Check that Spring AOT and GraalVM native image work by compiling the example
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: '25'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build example as native image
+        run: ./gradlew :spring-data-opensearch-examples:spring-boot-java-client-gradle:nativeCompile

--- a/README.md
+++ b/README.md
@@ -192,6 +192,17 @@ public interface PersonRepository extends ReactiveCrudRepository<Person, Long> {
 }
 ```
 
+## Spring AOT Support
+
+Spring Data OpenSearch supports [Spring Ahead of Time Optimizations](https://docs.spring.io/spring-framework/reference/core/aot.html)
+when using the new `OpenSearchClient`, enabling fast startup times and reduced memory footprint.
+
+The OpenSearch `RestHighLevelClient` is not supported for AOT.
+
+### Example
+
+See [spring-boot-java-client-gradle](spring-data-opensearch-examples/spring-boot-java-client-gradle) for a complete native image example.
+
 ### Using the OpenSearch RestClient
 
 Spring Data OpenSearch operates upon an OpenSearch client that is connected to a single OpenSearch node or a cluster. Although the OpenSearch Client can be used directly to work with the cluster, applications using Spring Data Elasticsearch normally use the higher level abstractions of `ElasticsearchOperations` and repositories (please consult [official Spring Data Elasticsearch documentation](https://docs.spring.io/spring-data/elasticsearch/docs/current/reference/html/)). Use the builder to provide cluster addresses, set default `HttpHeaders` or enable SSL.

--- a/buildSrc/src/main/kotlin/java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-conventions.gradle.kts
@@ -9,7 +9,6 @@ import java.util.Properties
 
 plugins {
   `java`
-  `java-library`
   `version-catalog`
   `maven-publish`
   jacoco

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,9 +15,9 @@ dependencyResolutionManagement {
     }
 
     create("springLibs") {
-      version("spring", "6.2.15")
-      version("spring-boot", "3.5.9")
-      library("data-commons", "org.springframework.data:spring-data-commons:3.5.7")
+      version("spring", "6.2.18")
+      version("spring-boot", "3.5.12")
+      library("data-commons", "org.springframework.data:spring-data-commons:3.5.11")
       library("data-elasticsearch", "org.springframework.data:spring-data-elasticsearch:5.5.11")
       library("web", "org.springframework", "spring-web").versionRef("spring")
       library("webflux", "org.springframework", "spring-webflux").versionRef("spring")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,7 +18,7 @@ dependencyResolutionManagement {
       version("spring", "6.2.15")
       version("spring-boot", "3.5.9")
       library("data-commons", "org.springframework.data:spring-data-commons:3.5.7")
-      library("data-elasticsearch", "org.springframework.data:spring-data-elasticsearch:5.5.7")
+      library("data-elasticsearch", "org.springframework.data:spring-data-elasticsearch:5.5.11")
       library("web", "org.springframework", "spring-web").versionRef("spring")
       library("webflux", "org.springframework", "spring-webflux").versionRef("spring")
       library("context", "org.springframework", "spring-context").versionRef("spring")

--- a/spring-data-opensearch-docker-compose/build.gradle.kts
+++ b/spring-data-opensearch-docker-compose/build.gradle.kts
@@ -6,6 +6,7 @@
 plugins {
   alias(pluginLibs.plugins.spotless)
   alias(pluginLibs.plugins.editorconfig)
+  `java-library`
   id("java-conventions")
 }
 

--- a/spring-data-opensearch-examples/spring-boot-gradle/build.gradle.kts
+++ b/spring-data-opensearch-examples/spring-boot-gradle/build.gradle.kts
@@ -18,8 +18,8 @@ buildscript {
 }
 
 dependencies {
-  api(project(":spring-data-opensearch"))
-  api(project(":spring-data-opensearch-starter"))
+  implementation(project(":spring-data-opensearch"))
+  implementation(project(":spring-data-opensearch-starter"))
   implementation(springLibs.boot.web)
   implementation(jacksonLibs.core)
   implementation(jacksonLibs.databind)

--- a/spring-data-opensearch-examples/spring-boot-java-client-gradle/README.md
+++ b/spring-data-opensearch-examples/spring-boot-java-client-gradle/README.md
@@ -42,3 +42,12 @@ docker run -p 9200:9200 -e "discovery.type=single-node" -e OPENSEARCH_INITIAL_AD
    - Fetch all products: `curl 'http://localhost:8080/marketplace/search'`
    - Search products by name: `curl 'http://localhost:8080/marketplace/search?name=pillow'`
    - Search products by name and price greater than: `curl 'http://localhost:8080/marketplace/search?name=pillow&price=35.0'`
+
+## Building as Native Image
+
+This example can be built as a [GraalVM](https://www.graalvm.org/) native image for fast startup and low memory usage.
+You can run build and run the native image using Gradle:
+
+```shell
+./gradlew :spring-data-opensearch-examples:spring-boot-java-client-gradle:nativeRun
+```

--- a/spring-data-opensearch-examples/spring-boot-java-client-gradle/build.gradle.kts
+++ b/spring-data-opensearch-examples/spring-boot-java-client-gradle/build.gradle.kts
@@ -19,10 +19,10 @@ buildscript {
 }
 
 dependencies {
-  api(project(":spring-data-opensearch")) {
+  implementation(project(":spring-data-opensearch")) {
     exclude("org.opensearch.client", "opensearch-rest-high-level-client")
   }
-  api(project(":spring-data-opensearch-starter")) {
+  implementation(project(":spring-data-opensearch-starter")) {
     exclude("org.opensearch.client", "opensearch-rest-high-level-client")
   }
   implementation(springLibs.boot.web)
@@ -53,14 +53,6 @@ dependencies {
 }
 
 description = "Spring Data OpenSearch Java Client Spring Boot Example Project"
-
-graalvmNative {
-  binaries {
-    named("main") {
-      sharedLibrary.set(false)
-    }
-  }
-}
 
 spotless {
   java {

--- a/spring-data-opensearch-examples/spring-boot-java-client-gradle/build.gradle.kts
+++ b/spring-data-opensearch-examples/spring-boot-java-client-gradle/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
   alias(pluginLibs.plugins.spotless)
   alias(pluginLibs.plugins.editorconfig)
   id("java-conventions")
+  id("org.graalvm.buildtools.native") version "0.11.5"
 }
 
 buildscript {
@@ -52,6 +53,14 @@ dependencies {
 }
 
 description = "Spring Data OpenSearch Java Client Spring Boot Example Project"
+
+graalvmNative {
+  binaries {
+    named("main") {
+      sharedLibrary.set(false)
+    }
+  }
+}
 
 spotless {
   java {

--- a/spring-data-opensearch-examples/spring-boot-java-client-gradle/src/main/java/org/opensearch/data/example/MarketplaceApplication.java
+++ b/spring-data-opensearch-examples/spring-boot-java-client-gradle/src/main/java/org/opensearch/data/example/MarketplaceApplication.java
@@ -8,10 +8,14 @@ package org.opensearch.data.example;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchDataAutoConfiguration;
+import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchClientAutoConfiguration;
 
-@SpringBootApplication(exclude = ElasticsearchDataAutoConfiguration.class)
+@SpringBootApplication(exclude = {
+    ElasticsearchDataAutoConfiguration.class,
+    ElasticsearchClientAutoConfiguration.class
+})
 public class MarketplaceApplication {
-    public static void main(String[] args) {
+    public static void main(final String[] args) {
         SpringApplication.run(MarketplaceConfiguration.class, args);
     }
 }

--- a/spring-data-opensearch-examples/spring-boot-reactive-client-gradle/build.gradle.kts
+++ b/spring-data-opensearch-examples/spring-boot-reactive-client-gradle/build.gradle.kts
@@ -18,10 +18,10 @@ buildscript {
 }
 
 dependencies {
-  api(project(":spring-data-opensearch")) {
+  implementation(project(":spring-data-opensearch")) {
     exclude("org.opensearch.client", "opensearch-rest-high-level-client")
   }
-  api(project(":spring-data-opensearch-starter")) {
+  implementation(project(":spring-data-opensearch-starter")) {
     exclude("org.opensearch.client", "opensearch-rest-high-level-client")
   }
   implementation(springLibs.boot.webflux)

--- a/spring-data-opensearch-starter/build.gradle.kts
+++ b/spring-data-opensearch-starter/build.gradle.kts
@@ -6,6 +6,7 @@
 plugins {
   alias(pluginLibs.plugins.spotless)
   alias(pluginLibs.plugins.editorconfig)
+  `java-library`
   id("java-conventions")
 }
 

--- a/spring-data-opensearch-test-autoconfigure/build.gradle.kts
+++ b/spring-data-opensearch-test-autoconfigure/build.gradle.kts
@@ -6,6 +6,7 @@
 plugins {
   alias(pluginLibs.plugins.spotless)
   alias(pluginLibs.plugins.editorconfig)
+  `java-library`
   id("java-conventions")
 }
 

--- a/spring-data-opensearch-testcontainers/build.gradle.kts
+++ b/spring-data-opensearch-testcontainers/build.gradle.kts
@@ -6,6 +6,7 @@
 plugins {
   alias(pluginLibs.plugins.spotless)
   alias(pluginLibs.plugins.editorconfig)
+  `java-library`
   id("java-conventions")
 }
 

--- a/spring-data-opensearch/build.gradle.kts
+++ b/spring-data-opensearch/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
   jacoco
   alias(pluginLibs.plugins.spotless)
   alias(pluginLibs.plugins.editorconfig)
+  `java-library`
   id("java-conventions")
 }
 

--- a/spring-data-opensearch/src/main/java/org/opensearch/data/aot/OpenSearchClientRuntimeHints.java
+++ b/spring-data-opensearch/src/main/java/org/opensearch/data/aot/OpenSearchClientRuntimeHints.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright OpenSearch Contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.data.aot;
+
+import org.opensearch.client.opensearch._types.mapping.RuntimeFieldType;
+import org.opensearch.client.opensearch._types.mapping.TypeMapping;
+import org.opensearch.client.opensearch.indices.IndexSettings;
+import org.opensearch.client.opensearch.indices.PutMappingRequest;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.aot.hint.TypeReference;
+import org.springframework.util.ClassUtils;
+
+/**
+ * Runtime hints for OpenSearch Java client library.
+ * `opensearch-java` does not provide its own hints since this is Spring-specific.
+ *
+ * @since 2.0.6
+ */
+public class OpenSearchClientRuntimeHints implements RuntimeHintsRegistrar {
+
+    @Override
+    public void registerHints(final RuntimeHints hints, final ClassLoader classLoader) {
+        // Reflection hints for JSON-B deserializers
+        hints.reflection()
+            .registerType(TypeReference.of(IndexSettings.class),
+                builder -> builder.withField("_DESERIALIZER"))
+            .registerType(TypeReference.of(PutMappingRequest.class),
+                builder -> builder.withField("_DESERIALIZER"))
+            .registerType(TypeReference.of(RuntimeFieldType.class),
+                builder -> builder.withField("_DESERIALIZER"))
+            .registerType(TypeReference.of(TypeMapping.class),
+                builder -> builder.withField("_DESERIALIZER"));
+
+        // Serialization hints for Apache HttpClient 5 (only if it is used)
+        if (ClassUtils.isPresent("org.apache.hc.client5.http.impl.auth.BasicScheme", classLoader)) {
+            hints.serialization()
+                .registerType(org.apache.hc.client5.http.impl.auth.BasicScheme.class)
+                .registerType(java.util.HashMap.class);
+        }
+
+        // Resource hints
+        hints.resources()
+            .registerPattern("org/opensearch/client/version.properties");
+    }
+}

--- a/spring-data-opensearch/src/main/java/org/opensearch/data/aot/SpringDataOpenSearchRuntimeHints.java
+++ b/spring-data-opensearch/src/main/java/org/opensearch/data/aot/SpringDataOpenSearchRuntimeHints.java
@@ -4,8 +4,9 @@
  */
 package org.opensearch.data.aot;
 
-import java.util.Arrays;
+import static org.springframework.data.elasticsearch.aot.ElasticsearchAotPredicates.isReactorPresent;
 
+import java.util.Arrays;
 import org.opensearch.data.client.osc.EntityAsMap;
 import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.RuntimeHints;
@@ -19,8 +20,6 @@ import org.springframework.data.elasticsearch.core.event.ReactiveAfterConvertCal
 import org.springframework.data.elasticsearch.core.event.ReactiveAfterLoadCallback;
 import org.springframework.data.elasticsearch.core.event.ReactiveAfterSaveCallback;
 import org.springframework.data.elasticsearch.core.event.ReactiveBeforeConvertCallback;
-
-import static org.springframework.data.elasticsearch.aot.ElasticsearchAotPredicates.isReactorPresent;
 
 /**
  * Runtime hints for Spring Data OpenSearch core functionality.

--- a/spring-data-opensearch/src/main/java/org/opensearch/data/aot/SpringDataOpenSearchRuntimeHints.java
+++ b/spring-data-opensearch/src/main/java/org/opensearch/data/aot/SpringDataOpenSearchRuntimeHints.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright OpenSearch Contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.data.aot;
+
+import java.util.Arrays;
+
+import org.opensearch.data.client.osc.EntityAsMap;
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.aot.hint.TypeReference;
+import org.springframework.data.elasticsearch.core.event.AfterConvertCallback;
+import org.springframework.data.elasticsearch.core.event.AfterLoadCallback;
+import org.springframework.data.elasticsearch.core.event.AfterSaveCallback;
+import org.springframework.data.elasticsearch.core.event.BeforeConvertCallback;
+import org.springframework.data.elasticsearch.core.event.ReactiveAfterConvertCallback;
+import org.springframework.data.elasticsearch.core.event.ReactiveAfterLoadCallback;
+import org.springframework.data.elasticsearch.core.event.ReactiveAfterSaveCallback;
+import org.springframework.data.elasticsearch.core.event.ReactiveBeforeConvertCallback;
+
+import static org.springframework.data.elasticsearch.aot.ElasticsearchAotPredicates.isReactorPresent;
+
+/**
+ * Runtime hints for Spring Data OpenSearch core functionality.
+ * Registers Spring Data callbacks and entity mapping classes.
+ *
+ * @since 2.0.6
+ */
+public class SpringDataOpenSearchRuntimeHints implements RuntimeHintsRegistrar {
+
+    @Override
+    public void registerHints(final RuntimeHints hints, final ClassLoader classLoader) {
+        // Register core callbacks (always present)
+        hints.reflection().registerTypes(
+            Arrays.asList(
+                TypeReference.of(AfterConvertCallback.class),
+                TypeReference.of(AfterLoadCallback.class),
+                TypeReference.of(AfterSaveCallback.class),
+                TypeReference.of(BeforeConvertCallback.class),
+                TypeReference.of(EntityAsMap.class)
+            ),
+            builder -> builder.withMembers(
+                MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
+                MemberCategory.INVOKE_PUBLIC_METHODS
+            )
+        );
+
+        // Register reactive callbacks (conditional on reactor presence)
+        if (isReactorPresent()) {
+            hints.reflection().registerTypes(
+                Arrays.asList(
+                    TypeReference.of(ReactiveAfterConvertCallback.class),
+                    TypeReference.of(ReactiveAfterLoadCallback.class),
+                    TypeReference.of(ReactiveAfterSaveCallback.class),
+                    TypeReference.of(ReactiveBeforeConvertCallback.class)
+                ),
+                builder -> builder.withMembers(
+                    MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
+                    MemberCategory.INVOKE_PUBLIC_METHODS
+                )
+            );
+        }
+    }
+}

--- a/spring-data-opensearch/src/main/java/org/opensearch/data/aot/package-info.java
+++ b/spring-data-opensearch/src/main/java/org/opensearch/data/aot/package-info.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright OpenSearch Contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * AOT and native image support for Spring Data OpenSearch.
+ */
+package org.opensearch.data.aot;

--- a/spring-data-opensearch/src/main/resources/META-INF/spring/aot.factories
+++ b/spring-data-opensearch/src/main/resources/META-INF/spring/aot.factories
@@ -1,0 +1,3 @@
+org.springframework.aot.hint.RuntimeHintsRegistrar=\
+  org.opensearch.data.aot.SpringDataOpenSearchRuntimeHints,\
+  org.opensearch.data.aot.OpenSearchClientRuntimeHints


### PR DESCRIPTION
### Description
this registers the necessary hints for [Ahead-of-Time Processing] to support both AOT and [GraalVM Native Image] usage. it also modifies one example application so that it can - optionally - be run as a native image to show that it works. this is also used in CI to test that it still builds.

on its own this will fail since by using AOT we automatically also pull in the AOT hints registered in `spring-data-elasticsearch` which in turn currently unconditionally registers hints for the Elasticsearch Client (ELC) which we however exclude as a transient dependency. thus a PR has been raised to make this optional: spring-projects/spring-data-elasticsearch#3267 this has been merged in `spring-data-elasticsearch` on `main` (v6.1.x), `6.0.x` and `5.5.x` and will be part of the next release of each of these versions. it has already been released as part of v5.5.11.

`ElasticsearchClientAutoConfiguration` also needs to be excluded in the `MarketplaceApplication` since otherwise two `JacksonJsonpMapper` beans will be present and the application will fail to start in the `processAot` phase.

`@since` is set to 2.0.6 since this will be cherry-picked also to that release, offering AOT & native image support on Spring Boot 3.5.x, 4.0.x and 4.1.x.

[Ahead-of-Time Processing]: https://docs.spring.io/spring-boot/reference/packaging/aot.html
[GraalVM Native Image]: https://docs.spring.io/spring-boot/reference/packaging/native-image/index.html

### Issues Resolved
Closes https://github.com/opensearch-project/spring-data-opensearch/issues/441

cherry-pick of #638 with the difference that here it already works (`spring-data-elasticsearch:5.5.11` has just been released today and i've updated to it in this commit; still waiting on `spring-data-elasticsearch:6.0.5`)

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
