### PR TITLE
Add Github workflow to automatically bump version (post release)

### DIFF
--- a/.ci/bump-version.sh
+++ b/.ci/bump-version.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -ex
+
+IFS='.' read -r -a VERSION_COMPONENTS <<< "$1"
+MAJOR="${VERSION_COMPONENTS[0]}"
+MINOR="${VERSION_COMPONENTS[1]}"
+PATCH="${VERSION_COMPONENTS[2]}"
+
+if [[ -z "$MAJOR" || -z "$MINOR" || -z "$PATCH" ]]; then
+  echo "Usage: $0 <major>.<minor>.<patch>"
+  exit 1
+fi
+
+VERSION="$MAJOR.$MINOR.$PATCH"
+
+s=$(command -v gsed || command -v sed)
+
+if [[ -z "$s" ]]; then
+  echo "sed command not found. Please install gsed or sed."
+  exit 1
+fi
+
+CURRENT_VERSION=`"$s" -E "s/^version=([0-9]+\.[0-9]+\.[0-9]+)$/\1/" version.properties`
+"$s" -i'' -E "s/^(version=)[0-9]+\.[0-9]+\.[0-9]+$/\1$VERSION/" version.properties
+"$s" -i'' -E "s/>[0-9]+\.[0-9]+\.[0-9]+</>$CURRENT_VERSION</" README.md
+

--- a/.github/actions/create-version-bump-pr/action.yml
+++ b/.github/actions/create-version-bump-pr/action.yml
@@ -1,0 +1,47 @@
+name: Create Version Bump Pull Request
+
+inputs:
+  branch:
+    description: 'Branch to bump version on'
+    required: true
+    type: string
+  version:
+    description: 'Version to bump to'
+    required: true
+    type: string
+  token:
+    description: 'GitHub Token'
+    required: true
+    type: string
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Checkout ${{ inputs.branch }}
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.branch }}
+        path: client
+
+    - name: Bump Version To ${{ inputs.version }}
+      shell: bash -eo pipefail {0}
+      run: bash .ci/bump-version.sh "$VERSION"
+      working-directory: client
+      env:
+        VERSION: ${{ inputs.version }}
+
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v7
+      with:
+        token: ${{ inputs.token }}
+        path: client
+        base: ${{ inputs.branch }}
+        branch: 'bump-version/${{ inputs.branch }}'
+        commit-message: Bump version to ${{ inputs.version }}
+        signoff: true
+        delete-branch: true
+        labels: |
+          autocut
+        title: '[AUTO] Bump version on `${{ inputs.branch }}` to `${{ inputs.version }}`'
+        body: |
+          Bumping version on `${{ inputs.branch }}` to `${{ inputs.version }}`.

--- a/.github/actions/create-version-bump-pr/action.yml
+++ b/.github/actions/create-version-bump-pr/action.yml
@@ -18,7 +18,7 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout ${{ inputs.branch }}
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: ${{ inputs.branch }}
         path: client

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,159 @@
+name: Bump Version
+
+on:
+  create:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to bump version on'
+        required: true
+      version:
+        description: 'Version to bump to'
+        required: true
+
+jobs:
+  bump-version-manual:
+    name: Bump Version (Manual)
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App Token
+        id: github_app_token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout .github/actions directory
+        uses: actions/checkout@v6
+        with:
+          path: gh
+          sparse-checkout: |
+            .github/actions
+          sparse-checkout-cone-mode: false
+
+      - name: Bump Version On ${{ inputs.branch }} Branch
+        uses: ./gh/.github/actions/create-version-bump-pr
+        with:
+          branch: ${{ inputs.branch }}
+          version: ${{ inputs.version }}
+          token: ${{ steps.github_app_token.outputs.token }}
+
+  bump-version-auto:
+    name: Bump Version On New Git Ref
+    if: github.event_name == 'create' && github.repository == 'opensearch-project/spring-data-opensearch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout .github/actions directory
+        uses: actions/checkout@v6
+        with:
+          path: gh
+          sparse-checkout: |
+            .github/actions
+          sparse-checkout-cone-mode: false
+
+      - name: Determine Git Ref Type
+        id: type
+        run: |
+          echo "Determining type of Git ref: ${GITHUB_REF}"
+
+          is_minor_indev_branch=false
+          is_patch_indev_branch=false
+          is_version_tag=false
+          major="0"
+          minor="0"
+          patch="0"
+          is_major_bump=false
+          is_minor_bump=false
+          
+          if [[ "${GITHUB_REF}" =~ ^refs/heads/([0-9]+)\.x$ ]]; then
+            is_minor_indev_branch=true
+            major="${BASH_REMATCH[1]}"
+          fi
+          
+          if [[ "${GITHUB_REF}" =~ ^refs/heads/([0-9]+)\.([0-9]+)$ ]]; then
+            is_patch_indev_branch=true
+            major="${BASH_REMATCH[1]}"
+            minor="${BASH_REMATCH[2]}"
+          fi
+          
+          if [[ "${GITHUB_REF}" =~ ^refs/tags/v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            is_version_tag=true
+            major="${BASH_REMATCH[1]}"
+            minor="${BASH_REMATCH[2]}"
+            patch="${BASH_REMATCH[3]}"
+
+            if [[ "${patch}" == "0" ]]; then
+              is_minor_bump=true
+
+              if [[ "${minor}" == "0" ]]; then
+                is_major_bump=true
+              fi
+            fi
+          fi
+          
+          {
+            echo "is_minor_indev_branch=${is_minor_indev_branch}"
+            echo "is_patch_indev_branch=${is_patch_indev_branch}"
+            echo "is_version_tag=${is_version_tag}"
+            echo "major=${major}"
+            echo "minor=${minor}"
+            echo "patch=${patch}"
+            echo "next_major_version=$((major + 1)).0.0"
+            echo "next_minor_version=${major}.$((minor + 1)).0"
+            echo "next_patch_version=${major}.${minor}.$((patch + 1))"
+            echo "minor_indev_branch_name=${major}.x"
+            echo "patch_indev_branch_name=${major}.${minor}"
+            echo "is_major_bump=${is_major_bump}"
+            echo "is_minor_bump=${is_minor_bump}"
+          } | tee -a "${GITHUB_ENV}"
+
+      - name: Generate GitHub App Token
+        id: github_app_token
+        uses: actions/create-github-app-token@v3
+        if: env.is_version_tag == 'true' || env.is_patch_indev_branch == 'true' || env.is_minor_indev_branch == 'true'
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Create ${{ env.patch_indev_branch_name }} Branch
+        if: false && env.is_minor_bump == 'true'
+        uses: peterjgrainger/action-create-branch@v4.0.0
+        with:
+          branch: ${{ env.patch_indev_branch_name }}
+          sha: ${{ github.sha }}
+        env:
+          GITHUB_TOKEN: ${{ steps.github_app_token.outputs.token }}
+
+      - name: Create ${{ env.minor_indev_branch_name }} Branch
+        if: env.is_major_bump == 'true'
+        uses: peterjgrainger/action-create-branch@v4.0.0
+        with:
+          branch: ${{ env.minor_indev_branch_name }}
+          sha: ${{ github.sha }}
+        env:
+          GITHUB_TOKEN: ${{ steps.github_app_token.outputs.token }}
+
+      - name: Bump Version On ${{ env.patch_indev_branch_name }} Branch
+        if: env.is_patch_indev_branch == 'true' || (env.is_version_tag == 'true' && env.patch > 0)
+        uses: ./gh/.github/actions/create-version-bump-pr
+        with:
+          branch: ${{ env.patch_indev_branch_name }}
+          version: ${{ env.next_patch_version }}
+          token: ${{ steps.github_app_token.outputs.token }}
+
+      - name: Bump Version On ${{ env.minor_indev_branch_name }} Branch
+        if: env.is_minor_indev_branch == 'true' || env.is_minor_bump == 'true'
+        uses: ./gh/.github/actions/create-version-bump-pr
+        with:
+          branch: ${{ env.minor_indev_branch_name }}
+          version: ${{ env.next_minor_version }}
+          token: ${{ steps.github_app_token.outputs.token }}
+
+      - name: Bump Version On main Branch
+        if: env.is_major_bump == 'true'
+        uses: ./gh/.github/actions/create-version-bump-pr
+        with:
+          branch: main
+          version: ${{ env.next_major_version }}
+          token: ${{ steps.github_app_token.outputs.token }}

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -65,18 +65,18 @@ jobs:
           patch="0"
           is_major_bump=false
           is_minor_bump=false
-          
+
           if [[ "${GITHUB_REF}" =~ ^refs/heads/([0-9]+)\.x$ ]]; then
             is_minor_indev_branch=true
             major="${BASH_REMATCH[1]}"
           fi
-          
+
           if [[ "${GITHUB_REF}" =~ ^refs/heads/([0-9]+)\.([0-9]+)$ ]]; then
             is_patch_indev_branch=true
             major="${BASH_REMATCH[1]}"
             minor="${BASH_REMATCH[2]}"
           fi
-          
+
           if [[ "${GITHUB_REF}" =~ ^refs/tags/v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
             is_version_tag=true
             major="${BASH_REMATCH[1]}"
@@ -91,7 +91,7 @@ jobs:
               fi
             fi
           fi
-          
+
           {
             echo "is_minor_indev_branch=${is_minor_indev_branch}"
             echo "is_patch_indev_branch=${is_patch_indev_branch}"
@@ -115,15 +115,6 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
-      - name: Create ${{ env.patch_indev_branch_name }} Branch
-        if: false && env.is_minor_bump == 'true'
-        uses: peterjgrainger/action-create-branch@v4.0.0
-        with:
-          branch: ${{ env.patch_indev_branch_name }}
-          sha: ${{ github.sha }}
-        env:
-          GITHUB_TOKEN: ${{ steps.github_app_token.outputs.token }}
 
       - name: Create ${{ env.minor_indev_branch_name }} Branch
         if: env.is_major_bump == 'true'


### PR DESCRIPTION
### Description
Add Github workflow to automatically bump version (post release)

### Issues Resolved
Adapted from https://github.com/opensearch-project/opensearch-java

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
