### PR TITLE
Actuator health check

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,6 +26,7 @@ dependencyResolutionManagement {
       library("test", "org.springframework", "spring-test").versionRef("spring")
       library("boot-web", "org.springframework.boot", "spring-boot-starter-web").versionRef("spring-boot")
       library("boot-webflux", "org.springframework.boot", "spring-boot-starter-webflux").versionRef("spring-boot")
+      library("boot-starter-actuator", "org.springframework.boot", "spring-boot-starter-actuator").versionRef("spring-boot")
       library("boot-autoconfigure", "org.springframework.boot", "spring-boot-autoconfigure").versionRef("spring-boot")
       library("boot-configuration-processor", "org.springframework.boot", "spring-boot-configuration-processor").versionRef("spring-boot")
       library("boot-docker-compose", "org.springframework.boot", "spring-boot-docker-compose").versionRef("spring-boot")

--- a/spring-data-opensearch-examples/spring-boot-gradle/src/main/resources/application.yml
+++ b/spring-data-opensearch-examples/spring-boot-gradle/src/main/resources/application.yml
@@ -6,9 +6,16 @@
 opensearch:
   uris: https://localhost:9200
   username: admin
-  password: admin
+  password: _Onetwothree88!
 
 spring:
+  elasticsearch:
+    restclient:
+      uris: "https://localhost:9200"
   jackson:
     serialization:
       INDENT_OUTPUT: true
+management:
+  health:
+    elasticsearch:
+      enabled: false

--- a/spring-data-opensearch-examples/spring-boot-gradle/src/main/resources/application.yml
+++ b/spring-data-opensearch-examples/spring-boot-gradle/src/main/resources/application.yml
@@ -2,20 +2,13 @@
 # Copyright OpenSearch Contributors.
 # SPDX-License-Identifier: Apache-2.0
 #
- 
+
 opensearch:
   uris: https://localhost:9200
   username: admin
-  password: _Onetwothree88!
+  password: admin
 
 spring:
-  elasticsearch:
-    restclient:
-      uris: "https://localhost:9200"
   jackson:
     serialization:
       INDENT_OUTPUT: true
-management:
-  health:
-    elasticsearch:
-      enabled: false

--- a/spring-data-opensearch-starter/build.gradle.kts
+++ b/spring-data-opensearch-starter/build.gradle.kts
@@ -22,6 +22,8 @@ dependencies {
   api(project(":spring-data-opensearch"))
   api(springLibs.boot.data.elasticsearch)
   api(springLibs.boot.elasticsearch)
+  // todo tlongo
+  implementation("org.springframework.boot:spring-boot-starter-actuator:4.0.6")
   implementation(opensearchLibs.client) {
     exclude("commons-logging", "commons-logging")
     exclude("org.slf4j", "slf4j-api")
@@ -36,6 +38,7 @@ dependencies {
     exclude("ch.qos.logback", "logback-classic")
   }
   testImplementation(springLibs.boot.test)
+//  testImplementation(springLibs.boot.starter.actuator)
   testImplementation(opensearchLibs.testcontainers)
   testImplementation(jacksonLibs.core)
   testImplementation(jacksonLibs.databind)

--- a/spring-data-opensearch-starter/build.gradle.kts
+++ b/spring-data-opensearch-starter/build.gradle.kts
@@ -22,8 +22,7 @@ dependencies {
   api(project(":spring-data-opensearch"))
   api(springLibs.boot.data.elasticsearch)
   api(springLibs.boot.elasticsearch)
-  // todo tlongo
-  implementation("org.springframework.boot:spring-boot-starter-actuator:4.0.6")
+  implementation(springLibs.boot.starter.actuator)
   implementation(opensearchLibs.client) {
     exclude("commons-logging", "commons-logging")
     exclude("org.slf4j", "slf4j-api")
@@ -38,7 +37,6 @@ dependencies {
     exclude("ch.qos.logback", "logback-classic")
   }
   testImplementation(springLibs.boot.test)
-//  testImplementation(springLibs.boot.starter.actuator)
   testImplementation(opensearchLibs.testcontainers)
   testImplementation(jacksonLibs.core)
   testImplementation(jacksonLibs.databind)

--- a/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/data/OpenSearchDataAutoConfiguration.java
+++ b/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/data/OpenSearchDataAutoConfiguration.java
@@ -17,6 +17,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.health.contributor.HealthIndicator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for Spring Data's OpenSearch support.
@@ -31,7 +32,7 @@ import org.springframework.context.annotation.Import;
 public class OpenSearchDataAutoConfiguration {
 
     @Bean
-    @ConditionalOnBean(OpenSearchRestTemplate.class)
+    @ConditionalOnBean(ElasticsearchOperations.class)
     @ConditionalOnMissingBean
     OpenSearchHealthIndicator openSearchHealthIndicator(OpenSearchRestTemplate template) {
         return new OpenSearchHealthIndicator(template);

--- a/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/data/OpenSearchDataAutoConfiguration.java
+++ b/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/data/OpenSearchDataAutoConfiguration.java
@@ -14,6 +14,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.health.autoconfigure.contributor.ConditionalOnEnabledHealthIndicator;
 import org.springframework.boot.health.contributor.HealthIndicator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
@@ -34,6 +35,7 @@ public class OpenSearchDataAutoConfiguration {
     @Bean
     @ConditionalOnBean(ElasticsearchOperations.class)
     @ConditionalOnMissingBean
+    @ConditionalOnEnabledHealthIndicator("opensearch")
     OpenSearchHealthIndicator openSearchHealthIndicator(OpenSearchRestTemplate template) {
         return new OpenSearchHealthIndicator(template);
     }

--- a/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/data/OpenSearchDataAutoConfiguration.java
+++ b/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/data/OpenSearchDataAutoConfiguration.java
@@ -11,7 +11,11 @@ import org.opensearch.spring.boot.autoconfigure.OpenSearchClientAutoConfiguratio
 import org.opensearch.spring.boot.autoconfigure.OpenSearchRestClientAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.health.contributor.HealthIndicator;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
 /**
@@ -21,7 +25,15 @@ import org.springframework.context.annotation.Import;
  * the needs of OpenSearch.
  */
 @AutoConfiguration(after = {OpenSearchClientAutoConfiguration.class, OpenSearchRestClientAutoConfiguration.class})
-@ConditionalOnClass({OpenSearchRestTemplate.class, OpenSearchTemplate.class})
+@ConditionalOnClass({OpenSearchRestTemplate.class, OpenSearchTemplate.class, HealthIndicator.class})
 @Import({OpenSearchDataConfiguration.BaseConfiguration.class, OpenSearchDataConfiguration.JavaClientConfiguration.class,
     OpenSearchDataConfiguration.ReactiveRestClientConfiguration.class})
-public class OpenSearchDataAutoConfiguration {}
+public class OpenSearchDataAutoConfiguration {
+
+    @Bean
+    @ConditionalOnBean(OpenSearchRestTemplate.class)
+    @ConditionalOnMissingBean
+    OpenSearchHealthIndicator openSearchHealthIndicator(OpenSearchRestTemplate template) {
+        return new OpenSearchHealthIndicator(template);
+    }
+}

--- a/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/data/OpenSearchHealthIndicator.java
+++ b/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/data/OpenSearchHealthIndicator.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright OpenSearch Contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.spring.boot.autoconfigure.data;
+
+import org.opensearch.data.client.orhlc.OpenSearchRestTemplate;
+import org.springframework.boot.health.contributor.AbstractHealthIndicator;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.Status;
+import org.springframework.data.elasticsearch.core.cluster.ClusterHealth;
+import org.springframework.stereotype.Component;
+
+@Component
+class OpenSearchHealthIndicator extends AbstractHealthIndicator {
+
+    private final OpenSearchRestTemplate template;
+
+    OpenSearchHealthIndicator(OpenSearchRestTemplate template) {
+        this.template = template;
+    }
+
+    @Override
+    protected void doHealthCheck(Health.Builder builder) {
+        processResponse(builder, template.cluster().health());
+    }
+
+    private void processResponse(Health.Builder builder, ClusterHealth response) {
+        if (response.isTimedOut()) {
+            builder.down().build();
+            return;
+        }
+
+        String status = response.getStatus();
+        builder.status("RED".equals(status) ? Status.OUT_OF_SERVICE : Status.UP);
+        builder.withDetail("cluster_name", response.getClusterName());
+        builder.withDetail("status", response.getStatus());
+        builder.withDetail("timed_out", response.isTimedOut());
+        builder.withDetail("number_of_nodes", response.getNumberOfNodes());
+        builder.withDetail("number_of_data_nodes", response.getNumberOfDataNodes());
+        builder.withDetail("active_primary_shards", response.getActivePrimaryShards());
+        builder.withDetail("active_shards", response.getActiveShards());
+        builder.withDetail("relocating_shards", response.getRelocatingShards());
+        builder.withDetail("initializing_shards", response.getInitializingShards());
+        builder.withDetail("unassigned_shards", response.getUnassignedShards());
+        builder.withDetail("delayed_unassigned_shards", response.getDelayedUnassignedShards());
+        builder.withDetail("number_of_pending_tasks", response.getNumberOfPendingTasks());
+        builder.withDetail("number_of_in_flight_fetch", response.getNumberOfInFlightFetch());
+        builder.withDetail("task_max_waiting_in_queue_millis", response.getTaskMaxWaitingTimeMillis());
+        builder.withDetail("active_shards_percent_as_number", response.getActiveShardsPercent());
+        builder.build();
+    }
+}
+

--- a/spring-data-opensearch-starter/src/test/java/org/opensearch/spring/boot/autoconfigure/data/OpenSearchDataAutoConfigurationTests.java
+++ b/spring-data-opensearch-starter/src/test/java/org/opensearch/spring/boot/autoconfigure/data/OpenSearchDataAutoConfigurationTests.java
@@ -29,9 +29,6 @@ import org.springframework.data.mapping.model.SimpleTypeHolder;
 
 /**
  * Tests for {@link OpenSearchDataAutoConfiguration}.
- *
- * Adaptation of the {@link org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchDataAutoConfigurationTests} to
- * the needs of OpenSearch.
  */
 class OpenSearchDataAutoConfigurationTests {
 
@@ -46,6 +43,7 @@ class OpenSearchDataAutoConfigurationTests {
     void defaultRestBeansRegistered() {
         this.contextRunner.run((context) -> assertThat(context)
                 .hasSingleBean(OpenSearchRestTemplate.class)
+                .hasSingleBean(OpenSearchHealthIndicator.class)
                 .hasSingleBean(ElasticsearchConverter.class)
                 .hasSingleBean(ElasticsearchCustomConversions.class));
     }

--- a/spring-data-opensearch-starter/src/test/java/org/opensearch/spring/boot/autoconfigure/data/OpenSearchDataAutoConfigurationTests.java
+++ b/spring-data-opensearch-starter/src/test/java/org/opensearch/spring/boot/autoconfigure/data/OpenSearchDataAutoConfigurationTests.java
@@ -90,6 +90,13 @@ class OpenSearchDataAutoConfigurationTests {
         });
     }
 
+    @Test
+    void healthIndicatorCanBeDisabled() {
+        this.contextRunner
+                .withPropertyValues("management.health.opensearch.enabled=false")
+                .run((context) -> assertThat(context).doesNotHaveBean(OpenSearchHealthIndicator.class));
+    }
+
     @Configuration(proxyBeanMethods = false)
     static class CustomOpenSearchCustomConversions {
 

--- a/spring-data-opensearch-starter/src/test/java/org/opensearch/spring/boot/autoconfigure/data/OpenSearchHealthIndicatorTests.java
+++ b/spring-data-opensearch-starter/src/test/java/org/opensearch/spring/boot/autoconfigure/data/OpenSearchHealthIndicatorTests.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright OpenSearch Contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.spring.boot.autoconfigure.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.data.client.orhlc.OpenSearchRestTemplate;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.Status;
+import org.springframework.data.elasticsearch.core.cluster.ClusterHealth;
+import org.springframework.data.elasticsearch.core.cluster.ClusterOperations;
+
+class OpenSearchHealthIndicatorTests {
+
+    @Test
+    void shouldReportDownWhenClusterHealthTimesOut() {
+        OpenSearchHealthIndicator indicator = new OpenSearchHealthIndicator(templateWithResponse(mockHealth("GREEN", true)));
+
+        Health health = indicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+        assertThat(health.getDetails()).isEmpty();
+    }
+
+    @Test
+    void shouldReportOutOfServiceForRedClusterStatusAndExposeExactDetailKeys() {
+        OpenSearchHealthIndicator indicator = new OpenSearchHealthIndicator(templateWithResponse(mockHealth("RED", false)));
+
+        Health health = indicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.OUT_OF_SERVICE);
+        assertThat(health.getDetails())
+                .containsOnlyKeys(
+                        "cluster_name",
+                        "status",
+                        "timed_out",
+                        "number_of_nodes",
+                        "number_of_data_nodes",
+                        "active_primary_shards",
+                        "active_shards",
+                        "relocating_shards",
+                        "initializing_shards",
+                        "unassigned_shards",
+                        "delayed_unassigned_shards",
+                        "number_of_pending_tasks",
+                        "number_of_in_flight_fetch",
+                        "task_max_waiting_in_queue_millis",
+                        "active_shards_percent_as_number");
+        assertThat(health.getDetails().get("status")).isEqualTo("RED");
+    }
+
+    @Test
+    void shouldReportUpForNonRedClusterStatus() {
+        OpenSearchHealthIndicator indicator = new OpenSearchHealthIndicator(templateWithResponse(mockHealth("YELLOW", false)));
+
+        Health health = indicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.UP);
+        assertThat(health.getDetails().get("status")).isEqualTo("YELLOW");
+    }
+
+    private OpenSearchRestTemplate templateWithResponse(ClusterHealth clusterHealth) {
+        OpenSearchRestTemplate template = mock(OpenSearchRestTemplate.class);
+        ClusterOperations clusterOperations = mock(ClusterOperations.class);
+        when(template.cluster()).thenReturn(clusterOperations);
+        when(clusterOperations.health()).thenReturn(clusterHealth);
+        return template;
+    }
+
+    private ClusterHealth mockHealth(String status, boolean timedOut) {
+        ClusterHealth clusterHealth = mock(ClusterHealth.class);
+        when(clusterHealth.isTimedOut()).thenReturn(timedOut);
+        when(clusterHealth.getStatus()).thenReturn(status);
+        when(clusterHealth.getClusterName()).thenReturn("cluster");
+        when(clusterHealth.getNumberOfNodes()).thenReturn(3);
+        when(clusterHealth.getNumberOfDataNodes()).thenReturn(2);
+        when(clusterHealth.getActivePrimaryShards()).thenReturn(10);
+        when(clusterHealth.getActiveShards()).thenReturn(20);
+        when(clusterHealth.getRelocatingShards()).thenReturn(1);
+        when(clusterHealth.getInitializingShards()).thenReturn(0);
+        when(clusterHealth.getUnassignedShards()).thenReturn(0);
+        when(clusterHealth.getDelayedUnassignedShards()).thenReturn(0);
+        when(clusterHealth.getNumberOfPendingTasks()).thenReturn(0);
+        when(clusterHealth.getNumberOfInFlightFetch()).thenReturn(0);
+        when(clusterHealth.getTaskMaxWaitingTimeMillis()).thenReturn(0L);
+        when(clusterHealth.getActiveShardsPercent()).thenReturn(100.0d);
+        return clusterHealth;
+    }
+}
+

--- a/spring-data-opensearch/src/main/java/org/opensearch/data/client/orhlc/AbstractOpenSearchConfiguration.java
+++ b/spring-data-opensearch/src/main/java/org/opensearch/data/client/orhlc/AbstractOpenSearchConfiguration.java
@@ -12,6 +12,7 @@ package org.opensearch.data.client.orhlc;
 import org.opensearch.client.RestHighLevelClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.elasticsearch.config.ElasticsearchConfigurationSupport;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.convert.ElasticsearchConverter;
 
 /**
@@ -34,7 +35,7 @@ public abstract class AbstractOpenSearchConfiguration extends ElasticsearchConfi
      * @return never {@literal null}.
      */
     @Bean(name = {"elasticsearchOperations", "elasticsearchTemplate", "opensearchTemplate"})
-    public OpenSearchRestTemplate elasticsearchOperations(
+    public ElasticsearchOperations elasticsearchOperations(
             ElasticsearchConverter elasticsearchConverter, RestHighLevelClient opensearchClient) {
 
         OpenSearchRestTemplate template = new OpenSearchRestTemplate(opensearchClient, elasticsearchConverter);

--- a/spring-data-opensearch/src/main/java/org/opensearch/data/client/orhlc/AbstractOpenSearchConfiguration.java
+++ b/spring-data-opensearch/src/main/java/org/opensearch/data/client/orhlc/AbstractOpenSearchConfiguration.java
@@ -12,7 +12,6 @@ package org.opensearch.data.client.orhlc;
 import org.opensearch.client.RestHighLevelClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.elasticsearch.config.ElasticsearchConfigurationSupport;
-import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.convert.ElasticsearchConverter;
 
 /**
@@ -35,7 +34,7 @@ public abstract class AbstractOpenSearchConfiguration extends ElasticsearchConfi
      * @return never {@literal null}.
      */
     @Bean(name = {"elasticsearchOperations", "elasticsearchTemplate", "opensearchTemplate"})
-    public ElasticsearchOperations elasticsearchOperations(
+    public OpenSearchRestTemplate elasticsearchOperations(
             ElasticsearchConverter elasticsearchConverter, RestHighLevelClient opensearchClient) {
 
         OpenSearchRestTemplate template = new OpenSearchRestTemplate(opensearchClient, elasticsearchConverter);


### PR DESCRIPTION
### Add OpenSearch Health Indicator for Spring Boot Actuator

This PR introduces an `OpenSearchHealthIndicator` that integrates with Spring Boot Actuator's health endpoint, allowing applications to monitor their OpenSearch cluster health via `/actuator/health`.

The indicator can be disabled via the standard Spring Boot `management.health.opensearch.enabled` property

```properties
  management.health.opensearch.enabled=false
 ```

### Issues Resolved
- https://github.com/opensearch-project/spring-data-opensearch/issues/132
  - Implementation is based on the one described in the issue
- related to: https://github.com/opensearch-project/spring-data-opensearch/issues/647 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
