### PR TITLE
Fix release workflows to use pre-releases and update releasing.md with new process

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -36,9 +36,10 @@ jobs:
         run: |
           ./gradlew --no-daemon -Dbuild.snapshot=false publishPublishMavenPublicationToLocalRepoRepository && tar -C build -cvf artifacts.tar.gz repository
       - name: Draft a release
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd
         with:
-          draft: true
-          generate_release_notes: true
-          files: |
-            artifacts.tar.gz
+          immutableCreate: true
+          generateReleaseNotes: true
+          artifacts: "artifacts.tar.gz"
+          prerelease: true
+

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -35,9 +35,9 @@ Repositories create consistent release labels, such as `v1.0.0`, `v1.1.0` and `v
 The release process is standard across repositories in this org and is run by a release manager volunteering from amongst [maintainers](MAINTAINERS.md).
 
 1. Create a tag, e.g. 1.0.0, and push it to this GitHub repository.
-1. The [release-drafter.yml](.github/workflows/release-drafter.yml) will be automatically kicked off and a draft release will be created.
-1. This draft release triggers the [jenkins release workflow](https://build.ci.opensearch.org/job/spring-data-opensearch-release) as a result of which the client is released on [maven central](https://search.maven.org/search?q=org.opensearch.client). Please note that the release workflow is triggered only if created release is in draft state.
-1. Once the above release workflow is successful, the drafted release on GitHub is published automatically.
+1. The [release-drafter.yml](.github/workflows/release-drafter.yml) will be automatically kicked off and a pre-release will be created.
+1. This pre-release triggers the [jenkins release workflow](https://build.ci.opensearch.org/job/spring-data-opensearch-release) as a result of which the client is released on [maven central](https://search.maven.org/search?q=org.opensearch.client). Please note that the release workflow is triggered only if created release is in pre-release state.
+1. Once the above release workflow is successful, it creates a GitHub issue requesting maintainers to manually publish the pre-release to release on GitHub.
 1. Increment "version" in [version.properties](./version.properties) to the next iteration, e.g. v2.1.1. See [example](https://github.com/opensearch-project/spring-data-opensearch/pull/75).
 
 ## Snapshot Builds

--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -1,4 +1,4 @@
-lib = library(identifier: 'jenkins@12.0.0', retriever: modernSCM([
+lib = library(identifier: 'jenkins@13.0.0', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))
@@ -7,8 +7,7 @@ standardReleasePipelineWithGenericTrigger(
     overrideDockerImage: 'opensearchstaging/ci-runner:release-centos7-clients-v4',
     tokenIdCredential: 'jenkins-spring-data-opensearch-generic-webhook-token',
     causeString: 'A tag was cut on opensearch-project/spring-data-opensearch repository causing this workflow to run',
-    downloadReleaseAsset: true,
-    publishRelease: true) {
+    downloadReleaseAsset: true) {
         publishToMaven(
             signingArtifactsPath: "$WORKSPACE/repository/",
             mavenArtifactsPath: "$WORKSPACE/repository/",


### PR DESCRIPTION
### Description
Recently we removed bot access to the repository. Due to which it is now unable to read draft releases. This PR fixes it by creating pre-release first, trigger jenkins workflow and then creates GH issue requesting maintainers to publish the release on the GitHub.

### Issues Resolved
https://github.com/opensearch-project/.github/issues/542
https://github.com/opensearch-project/opensearch-build/issues/6255

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
