### PR TITLE
Update jenkins image name to include ci-runner repo

### DIFF
--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -5,7 +5,7 @@ lib = library(identifier: 'jenkins@13.0.1', retriever: modernSCM([
 
 standardReleasePipelineWithGenericTrigger(
     overrideAgent: 'Jenkins-Agent-AL2023-X64-M54xlarge-Docker-Host',
-    overrideDockerImage: 'opensearchstaging/release-almalinux8-clients-v1',
+    overrideDockerImage: 'opensearchstaging/ci-runner:release-almalinux8-clients-v1',
     tokenIdCredential: 'jenkins-spring-data-opensearch-generic-webhook-token',
     causeString: 'A tag was cut on opensearch-project/spring-data-opensearch repository causing this workflow to run',
     downloadReleaseAsset: true) {


### PR DESCRIPTION
### Description
Update jenkins image name to include ci-runner repo#749


### Issues Resolved
https://github.com/opensearch-project/spring-data-opensearch/issues/745

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
