### PR TITLE
[Backport version.2.0.0] Bump jenkinslib 13.3.1 (#753)

### DIFF
--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -1,4 +1,4 @@
-lib = library(identifier: 'jenkins@13.0.0', retriever: modernSCM([
+lib = library(identifier: 'jenkins@13.3.1', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))


### PR DESCRIPTION
Backport https://github.com/opensearch-project/spring-data-opensearch/commit/00e1df74c264c5eff8af1b05bda963ab7cb82851 from https://github.com/opensearch-project/spring-data-opensearch/pull/753.