### PR TITLE
Bump 1password/load-secrets-action to v5.0.1 (spring-data-opensearch)

### DIFF
--- a/.github/workflows/publish-snapshots.yml
+++ b/.github/workflows/publish-snapshots.yml
@@ -20,7 +20,7 @@ jobs:
           java-version: 21
           distribution: 'temurin'
       - name: Load secret
-        uses: 1password/load-secrets-action@e544b780808654ba8ceba5fb2fe2897103d92ff4 # v5.0.0
+        uses: 1password/load-secrets-action@70062d7a876d3eb6334754fa26efd2fbd90c32f2 # v5.0.1
         with:
           # Export loaded secrets as environment variables
           export-env: true


### PR DESCRIPTION
### Description
Bump `1password/load-secrets-action` to v5.0.1 (pinned to commit `70062d7a876d3eb6334754fa26efd2fbd90c32f2`).

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6440#issuecomment-5349573946

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
