### PR TITLE
fix auto-config of Jackson: use Jackson 3 mapper

### DIFF
--- a/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/OpenSearchClientConfigurations.java
+++ b/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/OpenSearchClientConfigurations.java
@@ -9,7 +9,7 @@ import jakarta.json.bind.Jsonb;
 import jakarta.json.spi.JsonProvider;
 import org.opensearch.client.RestClient;
 import org.opensearch.client.json.JsonpMapper;
-import org.opensearch.client.json.jackson.JacksonJsonpMapper;
+import org.opensearch.client.json.jackson3.JacksonJsonpMapper;
 import org.opensearch.client.json.jsonb.JsonbJsonpMapper;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.transport.OpenSearchTransport;


### PR DESCRIPTION
### Description
`opensearch-java:3.9.0` introduced support for Jackson 3, commit 021f5fe9 added support for it here with the upgrade to Spring Boot 4.1 which replaces Jackson 2 with Jackson 3.
however, this contained a bug: it checks for the presence of the Jackson 3 `ObjectMapper`, however then it instantiates the Jackson 2 `JacksonJsonpMapper` from `opensearch-java`.
this fixes the import to use the Jackson 3 version.

### Issues Resolved
n/a (didn't raise one)

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
