### PR TITLE
Fix mapping customizer auto-configuration backoff

### DIFF
--- a/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/OpenSearchClientConfigurations.java
+++ b/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/OpenSearchClientConfigurations.java
@@ -74,7 +74,7 @@ class OpenSearchClientConfigurations {
     @Configuration(proxyBeanMethods = false)
     static class OpenSearchMappingParametersCustomizerConfiguration {
         @Bean
-        @ConditionalOnMissingBean(MappingParametersCustomizer.class)
+        @ConditionalOnMissingBean
         MappingParametersCustomizer opensearchMappingParametersCustomizer() {
             return new OpenSearchMappingParametersCustomizer();
         }

--- a/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/OpenSearchClientConfigurations.java
+++ b/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/OpenSearchClientConfigurations.java
@@ -75,7 +75,7 @@ class OpenSearchClientConfigurations {
     static class OpenSearchMappingParametersCustomizerConfiguration {
         @Bean
         @ConditionalOnMissingBean(MappingParametersCustomizer.class)
-        OpenSearchMappingParametersCustomizer opensearchMappingParametersCustomizer() {
+        MappingParametersCustomizer opensearchMappingParametersCustomizer() {
             return new OpenSearchMappingParametersCustomizer();
         }
     }

--- a/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/OpenSearchClientConfigurations.java
+++ b/spring-data-opensearch-starter/src/main/java/org/opensearch/spring/boot/autoconfigure/OpenSearchClientConfigurations.java
@@ -23,6 +23,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.elasticsearch.core.index.MappingParametersCustomizer;
 import tools.jackson.databind.ObjectMapper;
 
 class OpenSearchClientConfigurations {
@@ -73,7 +74,7 @@ class OpenSearchClientConfigurations {
     @Configuration(proxyBeanMethods = false)
     static class OpenSearchMappingParametersCustomizerConfiguration {
         @Bean
-        @ConditionalOnMissingBean
+        @ConditionalOnMissingBean(MappingParametersCustomizer.class)
         OpenSearchMappingParametersCustomizer opensearchMappingParametersCustomizer() {
             return new OpenSearchMappingParametersCustomizer();
         }

--- a/spring-data-opensearch-starter/src/test/java/org/opensearch/spring/boot/autoconfigure/OpenSearchClientAutoConfigurationTests.java
+++ b/spring-data-opensearch-starter/src/test/java/org/opensearch/spring/boot/autoconfigure/OpenSearchClientAutoConfigurationTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright OpenSearch Contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.spring.boot.autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.data.core.OpenSearchMappingParametersCustomizer;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.core.index.MappingParametersCustomizer;
+
+class OpenSearchClientAutoConfigurationTests {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(
+                    OpenSearchRestClientAutoConfiguration.class,
+                    OpenSearchClientAutoConfiguration.class));
+
+    @Test
+    void configuresDefaultMappingParametersCustomizer() {
+        this.contextRunner.run((context) -> assertThat(context)
+                .hasNotFailed()
+                .hasSingleBean(MappingParametersCustomizer.class)
+                .hasSingleBean(OpenSearchMappingParametersCustomizer.class));
+    }
+
+    @Test
+    void backsOffWhenMappingParametersCustomizerBeanUsesInterfaceReturnType() {
+        this.contextRunner
+                .withUserConfiguration(CustomMappingParametersCustomizerConfiguration.class)
+                .run((context) -> {
+                    assertThat(context).hasNotFailed().hasSingleBean(MappingParametersCustomizer.class);
+                    assertThat(context.getBean(MappingParametersCustomizer.class))
+                            .isSameAs(CustomMappingParametersCustomizerConfiguration.CUSTOMIZER);
+                });
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class CustomMappingParametersCustomizerConfiguration {
+
+        private static final MappingParametersCustomizer CUSTOMIZER = mock(MappingParametersCustomizer.class);
+
+        @Bean
+        MappingParametersCustomizer opensearchMappingParametersCustomizer() {
+            return CUSTOMIZER;
+        }
+    }
+}


### PR DESCRIPTION
### Description
Fixes a regression introduced in 3.1.2 affecting user-defined
  `MappingParametersCustomizer` beans.

  The starter previously inferred `@ConditionalOnMissingBean` from the concrete
  `OpenSearchMappingParametersCustomizer` factory return type. Because conditions
  are evaluated before bean instantiation, a user bean declared using the public
  `MappingParametersCustomizer` interface was not detected, resulting in a
  duplicate-name startup failure.

  The condition now explicitly targets `MappingParametersCustomizer`, ensuring
  user-provided interface implementations take precedence while retaining the
  default OpenSearch customizer when no user bean exists.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
