### PR TITLE
Bump org.opensearch.client:opensearch-java from 3.9.0 to 3.10.0

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -41,7 +41,7 @@ dependencyResolutionManagement {
     
     create("opensearchLibs") {
       version("opensearch", "3.8.0")
-      library("java-client", "org.opensearch.client:opensearch-java:3.9.0")
+      library("java-client", "org.opensearch.client:opensearch-java:3.10.0")
       library("client", "org.opensearch.client", "opensearch-rest-client").versionRef("opensearch")
       library("high-level-client", "org.opensearch.client", "opensearch-rest-high-level-client").versionRef("opensearch")
       library("sniffer", "org.opensearch.client", "opensearch-rest-client-sniffer").versionRef("opensearch")

--- a/spring-data-opensearch/src/main/java/org/opensearch/data/client/osc/DocumentAdapters.java
+++ b/spring-data-opensearch/src/main/java/org/opensearch/data/client/osc/DocumentAdapters.java
@@ -81,6 +81,9 @@ final class DocumentAdapters {
         Explanation explanation = from(hit.explanation());
 
         List<String> matchedQueries = hit.matchedQueries();
+        if (matchedQueries == null) {
+            matchedQueries = Collections.emptyList();
+        }
 
         Function<Map<String, JsonData>, EntityAsMap> fromFields = fields -> {
             StringBuilder sb = new StringBuilder("{");

--- a/spring-data-opensearch/src/test/java/org/opensearch/data/client/osc/DocumentAdaptersUnitTests.java
+++ b/spring-data-opensearch/src/test/java/org/opensearch/data/client/osc/DocumentAdaptersUnitTests.java
@@ -147,7 +147,7 @@ class DocumentAdaptersUnitTests {
         Hit<EntityAsMap> searchHit = new Hit.Builder<EntityAsMap>() //
                 .index("index") //
                 .id("42") //
-                .matchedQueries("query1", "query2") //
+                .matchedQueries(q -> q.names(List.of("query1", "query2"))) //
                 .build();
 
         SearchDocument searchDocument = DocumentAdapters.from(searchHit, jsonpMapper);


### PR DESCRIPTION
### Description
Bump org.opensearch.client:opensearch-java from 3.9.0 to 3.10.0

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
